### PR TITLE
Use different lodash import syntax which allows to include only used functions

### DIFF
--- a/src/0x.ts
+++ b/src/0x.ts
@@ -1,4 +1,4 @@
-import isUndefined from 'lodash/isUndefined';
+import isUndefined = require('lodash/isUndefined');
 import * as BigNumber from 'bignumber.js';
 import {bigNumberConfigs} from './bignumber_config';
 import * as ethUtil from 'ethereumjs-util';

--- a/src/0x.ts
+++ b/src/0x.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 import * as BigNumber from 'bignumber.js';
 import {bigNumberConfigs} from './bignumber_config';
 import * as ethUtil from 'ethereumjs-util';
@@ -239,10 +239,10 @@ export class ZeroEx {
     }
     private async _getExchangeAddressAsync() {
         const networkIdIfExists = await this._web3Wrapper.getNetworkIdIfExistsAsync();
-        const exchangeNetworkConfigsIfExists = _.isUndefined(networkIdIfExists) ?
+        const exchangeNetworkConfigsIfExists = isUndefined(networkIdIfExists) ?
                                        undefined :
                                        (ExchangeArtifacts as any).networks[networkIdIfExists];
-        if (_.isUndefined(exchangeNetworkConfigsIfExists)) {
+        if (isUndefined(exchangeNetworkConfigsIfExists)) {
             throw new Error(ZeroExError.CONTRACT_NOT_DEPLOYED_ON_NETWORK);
         }
         const exchangeAddress = exchangeNetworkConfigsIfExists.address;

--- a/src/contract_wrappers/contract_wrapper.ts
+++ b/src/contract_wrappers/contract_wrapper.ts
@@ -1,5 +1,5 @@
-import includes from 'lodash/includes';
-import isUndefined from 'lodash/isUndefined';
+import includes = require('lodash/includes');
+import isUndefined = require('lodash/isUndefined');
 import contract = require('truffle-contract');
 import {Web3Wrapper} from '../web3_wrapper';
 import {ZeroExError, Artifact, ContractInstance} from '../types';

--- a/src/contract_wrappers/contract_wrapper.ts
+++ b/src/contract_wrappers/contract_wrapper.ts
@@ -1,4 +1,5 @@
-import * as _ from 'lodash';
+import includes from 'lodash/includes';
+import isUndefined from 'lodash/isUndefined';
 import contract = require('truffle-contract');
 import {Web3Wrapper} from '../web3_wrapper';
 import {ZeroExError, Artifact, ContractInstance} from '../types';
@@ -15,17 +16,17 @@ export class ContractWrapper {
         c.setProvider(providerObj);
 
         const networkIdIfExists = await this._web3Wrapper.getNetworkIdIfExistsAsync();
-        const artifactNetworkConfigs = _.isUndefined(networkIdIfExists) ?
+        const artifactNetworkConfigs = isUndefined(networkIdIfExists) ?
                                        undefined :
                                        artifact.networks[networkIdIfExists];
         let contractAddress;
-        if (!_.isUndefined(address)) {
+        if (!isUndefined(address)) {
             contractAddress = address;
-        } else if (!_.isUndefined(artifactNetworkConfigs)) {
+        } else if (!isUndefined(artifactNetworkConfigs)) {
             contractAddress = artifactNetworkConfigs.address;
         }
 
-        if (!_.isUndefined(contractAddress)) {
+        if (!isUndefined(contractAddress)) {
             const doesContractExist = await this._web3Wrapper.doesContractExistAtAddressAsync(contractAddress);
             if (!doesContractExist) {
                 throw new Error(ZeroExError.CONTRACT_DOES_NOT_EXIST);
@@ -33,11 +34,11 @@ export class ContractWrapper {
         }
 
         try {
-            const contractInstance = _.isUndefined(address) ? await c.deployed() : await c.at(address);
+            const contractInstance = isUndefined(address) ? await c.deployed() : await c.at(address);
             return contractInstance;
         } catch (err) {
             const errMsg = `${err}`;
-            if (_.includes(errMsg, 'not been deployed to detected network')) {
+            if (includes(errMsg, 'not been deployed to detected network')) {
                 throw new Error(ZeroExError.CONTRACT_DOES_NOT_EXIST);
             } else {
                 utils.consoleLog(`Notice: Error encountered: ${err} ${err.stack}`);

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -1,4 +1,8 @@
-import * as _ from 'lodash';
+import map from 'lodash/map';
+import isEmpty from 'lodash/isEmpty';
+import find from 'lodash/find';
+import isUndefined from 'lodash/isUndefined';
+import unzip from 'lodash/unzip';
 import * as BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');
 import {Web3Wrapper} from '../web3_wrapper';
@@ -198,7 +202,7 @@ export class ExchangeWrapper extends ContractWrapper {
     @decorators.contractCallErrorHandler
     public async fillOrdersUpToAsync(signedOrders: SignedOrder[], takerTokenFillAmount: BigNumber.BigNumber,
                                      shouldCheckTransfer: boolean, takerAddress: string): Promise<void> {
-        const takerTokenAddresses = _.map(signedOrders, signedOrder => signedOrder.takerTokenAddress);
+        const takerTokenAddresses = map(signedOrders, signedOrder => signedOrder.takerTokenAddress);
         assert.hasAtMostOneUniqueValue(takerTokenAddresses,
                                         ExchangeContractErrs.MULTIPLE_TAKER_TOKENS_IN_FILL_UP_TO_DISALLOWED);
         assert.isBigNumber('takerTokenFillAmount', takerTokenFillAmount);
@@ -209,11 +213,11 @@ export class ExchangeWrapper extends ContractWrapper {
             await this._validateFillOrderAndThrowIfInvalidAsync(
                 signedOrder, takerTokenFillAmount, takerAddress);
         }
-        if (_.isEmpty(signedOrders)) {
+        if (isEmpty(signedOrders)) {
             return; // no-op
         }
 
-        const orderAddressesValuesAndSignatureArray = _.map(signedOrders, signedOrder => {
+        const orderAddressesValuesAndSignatureArray = map(signedOrders, signedOrder => {
             return [
                 ...ExchangeWrapper._getOrderAddressesAndValues(signedOrder),
                 signedOrder.ecSignature.v,
@@ -221,8 +225,8 @@ export class ExchangeWrapper extends ContractWrapper {
                 signedOrder.ecSignature.s,
             ];
         });
-        // We use _.unzip<any> because _.unzip doesn't type check if values have different types :'(
-        const [orderAddressesArray, orderValuesArray, vArray, rArray, sArray] = _.unzip<any>(
+        // We use unzip<any> because unzip doesn't type check if values have different types :'(
+        const [orderAddressesArray, orderValuesArray, vArray, rArray, sArray] = unzip<any>(
             orderAddressesValuesAndSignatureArray,
         );
 
@@ -277,11 +281,11 @@ export class ExchangeWrapper extends ContractWrapper {
             await this._validateFillOrderAndThrowIfInvalidAsync(
                 orderFillRequest.signedOrder, orderFillRequest.takerTokenFillAmount, takerAddress);
         }
-        if (_.isEmpty(orderFillRequests)) {
+        if (isEmpty(orderFillRequests)) {
             return; // no-op
         }
 
-        const orderAddressesValuesAmountsAndSignatureArray = _.map(orderFillRequests, orderFillRequest => {
+        const orderAddressesValuesAmountsAndSignatureArray = map(orderFillRequests, orderFillRequest => {
             return [
                 ...ExchangeWrapper._getOrderAddressesAndValues(orderFillRequest.signedOrder),
                 orderFillRequest.takerTokenFillAmount,
@@ -290,8 +294,8 @@ export class ExchangeWrapper extends ContractWrapper {
                 orderFillRequest.signedOrder.ecSignature.s,
             ];
         });
-        // We use _.unzip<any> because _.unzip doesn't type check if values have different types :'(
-        const [orderAddressesArray, orderValuesArray, takerTokenFillAmountArray, vArray, rArray, sArray] = _.unzip<any>(
+        // We use unzip<any> because unzip doesn't type check if values have different types :'(
+        const [orderAddressesArray, orderValuesArray, takerTokenFillAmountArray, vArray, rArray, sArray] = unzip<any>(
             orderAddressesValuesAmountsAndSignatureArray,
         );
 
@@ -390,7 +394,7 @@ export class ExchangeWrapper extends ContractWrapper {
                                                                      request.fillTakerAmount);
         }
 
-        const orderAddressesValuesAndTakerTokenFillAmounts = _.map(orderFillOrKillRequests, request => {
+        const orderAddressesValuesAndTakerTokenFillAmounts = map(orderFillOrKillRequests, request => {
             return [
                 ...ExchangeWrapper._getOrderAddressesAndValues(request.signedOrder),
                 request.fillTakerAmount,
@@ -400,9 +404,9 @@ export class ExchangeWrapper extends ContractWrapper {
             ];
         });
 
-        // We use _.unzip<any> because _.unzip doesn't type check if values have different types :'(
+        // We use unzip<any> because unzip doesn't type check if values have different types :'(
         const [orderAddresses, orderValues, fillTakerAmounts, vParams, rParams, sParams] =
-              _.unzip<any>(orderAddressesValuesAndTakerTokenFillAmounts);
+              unzip<any>(orderAddressesValuesAndTakerTokenFillAmounts);
 
         const gas = await exchangeInstance.batchFillOrKill.estimateGas(
             orderAddresses,
@@ -473,7 +477,7 @@ export class ExchangeWrapper extends ContractWrapper {
      */
     @decorators.contractCallErrorHandler
     public async batchCancelOrderAsync(orderCancellationRequests: OrderCancellationRequest[]): Promise<void> {
-        const makers = _.map(orderCancellationRequests, cancellationRequest => cancellationRequest.order.maker);
+        const makers = map(orderCancellationRequests, cancellationRequest => cancellationRequest.order.maker);
         assert.hasAtMostOneUniqueValue(makers, ExchangeContractErrs.MULTIPLE_MAKERS_IN_SINGLE_CANCEL_BATCH_DISALLOWED);
         const maker = makers[0];
         await assert.isSenderAddressAsync('maker', maker, this._web3Wrapper);
@@ -484,19 +488,19 @@ export class ExchangeWrapper extends ContractWrapper {
                 cancellationRequest.order, cancellationRequest.takerTokenCancelAmount,
             );
         }
-        if (_.isEmpty(orderCancellationRequests)) {
+        if (isEmpty(orderCancellationRequests)) {
             return; // no-op
         }
         const exchangeInstance = await this._getExchangeContractAsync();
-        const orderAddressesValuesAndTakerTokenCancelAmounts = _.map(orderCancellationRequests, cancellationRequest => {
+        const orderAddressesValuesAndTakerTokenCancelAmounts = map(orderCancellationRequests, cancellationRequest => {
             return [
                 ...ExchangeWrapper._getOrderAddressesAndValues(cancellationRequest.order),
                 cancellationRequest.takerTokenCancelAmount,
             ];
         });
-        // We use _.unzip<any> because _.unzip doesn't type check if values have different types :'(
+        // We use unzip<any> because unzip doesn't type check if values have different types :'(
         const [orderAddresses, orderValues, takerTokenCancelAmounts] =
-            _.unzip<any>(orderAddressesValuesAndTakerTokenCancelAmounts);
+            unzip<any>(orderAddressesValuesAndTakerTokenCancelAmounts);
         const gas = await exchangeInstance.batchCancel.estimateGas(
             orderAddresses,
             orderValues,
@@ -561,7 +565,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * Stops watching for all exchange events
      */
     public async stopWatchingAllEventsAsync(): Promise<void> {
-        const stopWatchingPromises = _.map(this._exchangeLogEventEmitters,
+        const stopWatchingPromises = map(this._exchangeLogEventEmitters,
                                            logEventObj => logEventObj.stopWatchingAsync());
         await Promise.all(stopWatchingPromises);
         this._exchangeLogEventEmitters = [];
@@ -715,8 +719,8 @@ export class ExchangeWrapper extends ContractWrapper {
         }
     }
     private _throwErrorLogsAsErrors(logs: ContractEvent[]): void {
-        const errEvent = _.find(logs, {event: 'LogError'});
-        if (!_.isUndefined(errEvent)) {
+        const errEvent = find(logs, {event: 'LogError'});
+        if (!isUndefined(errEvent)) {
             const errCode = (errEvent.args as LogErrorContractEventArgs).errorId.toNumber();
             const errMessage = this._exchangeContractErrCodesToMsg[errCode];
             throw new Error(errMessage);
@@ -733,7 +737,7 @@ export class ExchangeWrapper extends ContractWrapper {
         return isRoundingError;
     }
     private async _getExchangeContractAsync(): Promise<ExchangeContract> {
-        if (!_.isUndefined(this._exchangeContractIfExists)) {
+        if (!isUndefined(this._exchangeContractIfExists)) {
             return this._exchangeContractIfExists;
         }
         const contractInstance = await this._instantiateContractIfExistsAsync((ExchangeArtifacts as any));

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -1,8 +1,8 @@
-import map from 'lodash/map';
-import isEmpty from 'lodash/isEmpty';
-import find from 'lodash/find';
-import isUndefined from 'lodash/isUndefined';
-import unzip from 'lodash/unzip';
+import map = require('lodash/map');
+import isEmpty = require('lodash/isEmpty');
+import find = require('lodash/find');
+import isUndefined = require('lodash/isUndefined');
+import unzip = require('lodash/unzip');
 import * as BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');
 import {Web3Wrapper} from '../web3_wrapper';

--- a/src/contract_wrappers/token_registry_wrapper.ts
+++ b/src/contract_wrappers/token_registry_wrapper.ts
@@ -1,5 +1,5 @@
-import map from 'lodash/map';
-import isUndefined from 'lodash/isUndefined';
+import map = require('lodash/map');
+import isUndefined = require('lodash/isUndefined');
 import {Web3Wrapper} from '../web3_wrapper';
 import {Token, TokenRegistryContract, TokenMetadata} from '../types';
 import {assert} from '../utils/assert';

--- a/src/contract_wrappers/token_registry_wrapper.ts
+++ b/src/contract_wrappers/token_registry_wrapper.ts
@@ -1,4 +1,5 @@
-import * as _ from 'lodash';
+import map from 'lodash/map';
+import isUndefined from 'lodash/isUndefined';
 import {Web3Wrapper} from '../web3_wrapper';
 import {Token, TokenRegistryContract, TokenMetadata} from '../types';
 import {assert} from '../utils/assert';
@@ -24,12 +25,12 @@ export class TokenRegistryWrapper extends ContractWrapper {
         const tokenRegistryContract = await this._getTokenRegistryContractAsync();
 
         const addresses = await tokenRegistryContract.getTokenAddresses.call();
-        const tokenMetadataPromises: Array<Promise<TokenMetadata>> = _.map(
+        const tokenMetadataPromises: Array<Promise<TokenMetadata>> = map(
             addresses,
             (address: string) => (tokenRegistryContract.getTokenMetaData.call(address)),
         );
         const tokensMetadata = await Promise.all(tokenMetadataPromises);
-        const tokens = _.map(tokensMetadata, metadata => {
+        const tokens = map(tokensMetadata, metadata => {
             return {
                 address: metadata[0],
                 name: metadata[1],
@@ -41,7 +42,7 @@ export class TokenRegistryWrapper extends ContractWrapper {
         return tokens;
     }
     private async _getTokenRegistryContractAsync(): Promise<TokenRegistryContract> {
-        if (!_.isUndefined(this._tokenRegistryContractIfExists)) {
+        if (!isUndefined(this._tokenRegistryContractIfExists)) {
             return this._tokenRegistryContractIfExists;
         }
         const contractInstance = await this._instantiateContractIfExistsAsync((TokenRegistryArtifacts as any));

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -1,4 +1,4 @@
-import isUndefined from 'lodash/isUndefined';
+import isUndefined = require('lodash/isUndefined');
 import * as BigNumber from 'bignumber.js';
 import {Web3Wrapper} from '../web3_wrapper';
 import {assert} from '../utils/assert';

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import isUndefined from 'lodash/isUndefined';
 import * as BigNumber from 'bignumber.js';
 import {Web3Wrapper} from '../web3_wrapper';
 import {assert} from '../utils/assert';
@@ -179,7 +179,7 @@ export class TokenWrapper extends ContractWrapper {
     }
     private async _getTokenContractAsync(tokenAddress: string): Promise<TokenContract> {
         let tokenContract = this._tokenContractsByAddress[tokenAddress];
-        if (!_.isUndefined(tokenContract)) {
+        if (!isUndefined(tokenContract)) {
             return tokenContract;
         }
         const contractInstance = await this._instantiateContractIfExistsAsync((TokenArtifacts as any), tokenAddress);
@@ -189,10 +189,10 @@ export class TokenWrapper extends ContractWrapper {
     }
     private async _getProxyAddressAsync() {
         const networkIdIfExists = await this._web3Wrapper.getNetworkIdIfExistsAsync();
-        const proxyNetworkConfigsIfExists = _.isUndefined(networkIdIfExists) ?
+        const proxyNetworkConfigsIfExists = isUndefined(networkIdIfExists) ?
                                        undefined :
                                        (ProxyArtifacts as any).networks[networkIdIfExists];
-        if (_.isUndefined(proxyNetworkConfigsIfExists)) {
+        if (isUndefined(proxyNetworkConfigsIfExists)) {
             throw new Error(ZeroExError.CONTRACT_NOT_DEPLOYED_ON_NETWORK);
         }
         const proxyAddress = proxyNetworkConfigsIfExists.address;

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,4 @@
-import reduce from 'lodash/reduce';
+import reduce = require('lodash/reduce');
 import * as Web3 from 'web3';
 
 // Utility function to create a K:V from a list of strings

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,10 +1,10 @@
-import * as _ from 'lodash';
+import reduce from 'lodash/reduce';
 import * as Web3 from 'web3';
 
 // Utility function to create a K:V from a list of strings
 // Adapted from: https://basarat.gitbooks.io/typescript/content/docs/types/literal-types.html
 function strEnum(values: string[]): {[key: string]: string} {
-    return _.reduce(values, (result, key) => {
+    return reduce(values, (result, key) => {
         result[key] = key;
         return result;
     }, Object.create(null));

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,10 +1,10 @@
-import uniq from 'lodash/uniq';
-import isEmpty from 'lodash/isEmpty';
-import isObject from 'lodash/isObject';
-import isFinite from 'lodash/isFinite';
-import isString from 'lodash/isString';
-import isBoolean from 'lodash/isBoolean';
-import isUndefined from 'lodash/isUndefined';
+import uniq = require('lodash/uniq');
+import isEmpty = require('lodash/isEmpty');
+import isObject = require('lodash/isObject');
+import isFinite = require('lodash/isFinite');
+import isString = require('lodash/isString');
+import isBoolean = require('lodash/isBoolean');
+import isUndefined = require('lodash/isUndefined');
 import * as BigNumber from 'bignumber.js';
 import * as Web3 from 'web3';
 import {Web3Wrapper} from '../web3_wrapper';

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,4 +1,10 @@
-import * as _ from 'lodash';
+import uniq from 'lodash/uniq';
+import isEmpty from 'lodash/isEmpty';
+import isObject from 'lodash/isObject';
+import isFinite from 'lodash/isFinite';
+import isString from 'lodash/isString';
+import isBoolean from 'lodash/isBoolean';
+import isUndefined from 'lodash/isUndefined';
 import * as BigNumber from 'bignumber.js';
 import * as Web3 from 'web3';
 import {Web3Wrapper} from '../web3_wrapper';
@@ -9,17 +15,17 @@ const HEX_REGEX = /^0x[0-9A-F]*$/i;
 
 export const assert = {
     isBigNumber(variableName: string, value: BigNumber.BigNumber): void {
-        const isBigNumber = _.isObject(value) && value.isBigNumber;
+        const isBigNumber = isObject(value) && value.isBigNumber;
         this.assert(isBigNumber, this.typeAssertionMessage(variableName, 'BigNumber', value));
     },
     isUndefined(value: any, variableName?: string): void {
-        this.assert(_.isUndefined(value), this.typeAssertionMessage(variableName, 'undefined', value));
+        this.assert(isUndefined(value), this.typeAssertionMessage(variableName, 'undefined', value));
     },
     isString(variableName: string, value: string): void {
-        this.assert(_.isString(value), this.typeAssertionMessage(variableName, 'string', value));
+        this.assert(isString(value), this.typeAssertionMessage(variableName, 'string', value));
     },
     isHexString(variableName: string, value: string): void {
-        this.assert(_.isString(value) && HEX_REGEX.test(value),
+        this.assert(isString(value) && HEX_REGEX.test(value),
             this.typeAssertionMessage(variableName, 'HexString', value));
     },
     isETHAddressHex(variableName: string, value: string): void {
@@ -36,19 +42,19 @@ export const assert = {
     },
     async isUserAddressAvailableAsync(web3Wrapper: Web3Wrapper): Promise<void> {
         const availableAddresses = await web3Wrapper.getAvailableAddressesAsync();
-        this.assert(!_.isEmpty(availableAddresses), 'No addresses were available on the provided web3 instance');
+        this.assert(!isEmpty(availableAddresses), 'No addresses were available on the provided web3 instance');
     },
     hasAtMostOneUniqueValue(value: any[], errMsg: string): void {
-        this.assert(_.uniq(value).length <= 1, errMsg);
+        this.assert(uniq(value).length <= 1, errMsg);
     },
     isNumber(variableName: string, value: number): void {
-        this.assert(_.isFinite(value), this.typeAssertionMessage(variableName, 'number', value));
+        this.assert(isFinite(value), this.typeAssertionMessage(variableName, 'number', value));
     },
     isValidOrderHash(variableName: string, value: string): void {
         this.assert(utils.isValidOrderHash(value), this.typeAssertionMessage(variableName, 'orderHash', value));
     },
     isBoolean(variableName: string, value: boolean): void {
-        this.assert(_.isBoolean(value), this.typeAssertionMessage(variableName, 'boolean', value));
+        this.assert(isBoolean(value), this.typeAssertionMessage(variableName, 'boolean', value));
     },
     doesConformToSchema(variableName: string, value: object, schema: Schema): void {
         const schemaValidator = new SchemaValidator();

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,4 +1,4 @@
-import includes from 'lodash/includes';
+import includes = require('lodash/includes');
 import {constants} from './constants';
 import {AsyncMethod, ZeroExError} from '../types';
 

--- a/src/utils/decorators.ts
+++ b/src/utils/decorators.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import includes from 'lodash/includes';
 import {constants} from './constants';
 import {AsyncMethod, ZeroExError} from '../types';
 
@@ -20,10 +20,10 @@ export const decorators = {
                 const result = await originalMethod.apply(this, args);
                 return result;
             } catch (error) {
-                if (_.includes(error.message, constants.INVALID_JUMP_PATTERN)) {
+                if (includes(error.message, constants.INVALID_JUMP_PATTERN)) {
                     throw new Error(ZeroExError.INVALID_JUMP);
                 }
-                if (_.includes(error.message, constants.OUT_OF_GAS_PATTERN)) {
+                if (includes(error.message, constants.OUT_OF_GAS_PATTERN)) {
                     throw new Error(ZeroExError.OUT_OF_GAS);
                 }
                 throw error;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,4 +1,5 @@
-import * as _ from 'lodash';
+import map from 'lodash/map';
+import includes from 'lodash/includes';
 import * as BN from 'bn.js';
 import * as ethABI from 'ethereumjs-abi';
 import * as ethUtil from 'ethereumjs-util';
@@ -20,7 +21,7 @@ export const utils = {
         console.log(message);
     },
     isParityNode(nodeVersion: string): boolean {
-        return _.includes(nodeVersion, 'Parity');
+        return includes(nodeVersion, 'Parity');
     },
     isValidOrderHash(orderHashHex: string): boolean {
         const isValid = /^0x[0-9A-F]{64}$/i.test(orderHashHex);
@@ -44,8 +45,8 @@ export const utils = {
             {value: utils.bigNumberToBN(order.expirationUnixTimestampSec), type: SolidityTypes.uint256},
             {value: utils.bigNumberToBN(order.salt), type: SolidityTypes.uint256},
         ];
-        const types = _.map(orderParts, o => o.type);
-        const values = _.map(orderParts, o => o.value);
+        const types = map(orderParts, o => o.type);
+        const values = map(orderParts, o => o.value);
         const hashBuff = ethABI.soliditySHA3(types, values);
         const hashHex = ethUtil.bufferToHex(hashBuff);
         return hashHex;

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -1,5 +1,5 @@
-import map from 'lodash/map';
-import includes from 'lodash/includes';
+import map = require('lodash/map');
+import includes = require('lodash/includes');
 import * as BN from 'bn.js';
 import * as ethABI from 'ethereumjs-abi';
 import * as ethUtil from 'ethereumjs-util';

--- a/src/web3_wrapper.ts
+++ b/src/web3_wrapper.ts
@@ -1,4 +1,4 @@
-import includes from 'lodash/includes';
+import includes = require('lodash/includes');
 import * as Web3 from 'web3';
 import * as BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');

--- a/src/web3_wrapper.ts
+++ b/src/web3_wrapper.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import includes from 'lodash/includes';
 import * as Web3 from 'web3';
 import * as BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');
@@ -17,7 +17,7 @@ export class Web3Wrapper {
     }
     public async isSenderAddressAvailableAsync(senderAddress: string): Promise<boolean> {
         const addresses = await this.getAvailableAddressesAsync();
-        return _.includes(addresses, senderAddress);
+        return includes(addresses, senderAddress);
     }
     public async getNodeVersionAsync(): Promise<string> {
         const nodeVersion = await promisify(this.web3.version.getNode)();

--- a/test/0x.js_test.ts
+++ b/test/0x.js_test.ts
@@ -1,4 +1,5 @@
-import * as _ from 'lodash';
+import each from 'lodash/each';
+import assign from 'lodash/assign';
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';
 import 'mocha';
@@ -67,7 +68,7 @@ describe('ZeroEx library', () => {
             ).to.become(false);
         });
         it('should return false if the signature doesn\'t pertain to the dataHex & address', async () => {
-            const wrongSignature = _.assign({}, signature, {v: 28});
+            const wrongSignature = assign({}, signature, {v: 28});
             expect(ZeroEx.isValidSignature(dataHex, wrongSignature, address)).to.be.false();
             return expect(
                 (zeroEx.exchange as any)._isValidSignatureUsingContractCallAsync(dataHex, wrongSignature, address),
@@ -144,7 +145,7 @@ describe('ZeroEx library', () => {
         let stubs: Sinon.SinonStub[] = [];
         afterEach(() => {
             // clean up any stubs after the test has completed
-            _.each(stubs, s => s.restore());
+            each(stubs, s => s.restore());
             stubs = [];
         });
         it('calculates the order hash', async () => {
@@ -171,7 +172,7 @@ describe('ZeroEx library', () => {
         });
         afterEach(() => {
             // clean up any stubs after the test has completed
-            _.each(stubs, s => s.restore());
+            each(stubs, s => s.restore());
             stubs = [];
         });
         it ('Should return the correct ECSignature on TestPRC nodeVersion', async () => {

--- a/test/0x.js_test.ts
+++ b/test/0x.js_test.ts
@@ -1,5 +1,5 @@
-import each from 'lodash/each';
-import assign from 'lodash/assign';
+import each = require('lodash/each');
+import assign = require('lodash/assign');
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';
 import 'mocha';

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -1,5 +1,5 @@
 import 'mocha';
-import forEach from 'lodash/forEach';
+import forEach = require('lodash/forEach');
 import * as chai from 'chai';
 import * as BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');

--- a/test/schema_test.ts
+++ b/test/schema_test.ts
@@ -1,5 +1,5 @@
 import 'mocha';
-import * as _ from 'lodash';
+import forEach from 'lodash/forEach';
 import * as chai from 'chai';
 import * as BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');
@@ -19,7 +19,7 @@ const expect = chai.expect;
 describe('Schema', () => {
     const validator = new SchemaValidator();
     const validateAgainstSchema = (testCases: any[], schema: any, shouldFail = false) => {
-        _.forEach(testCases, (testCase: any) => {
+        forEach(testCases, (testCase: any) => {
             if (shouldFail) {
                 expect(validator.validate(testCase, schema).errors).to.be.lengthOf.at.least(1);
             } else {
@@ -285,7 +285,7 @@ describe('Schema', () => {
                 '00.00': '0',
                 '.3': '0.3',
             };
-            _.forEach(testCases, (serialized: string, input: string) => {
+            forEach(testCases, (serialized: string, input: string) => {
                 expect(JSON.parse(JSON.stringify(new BigNumber(input)))).to.be.equal(serialized);
             });
         });

--- a/test/token_registry_wrapper_test.ts
+++ b/test/token_registry_wrapper_test.ts
@@ -1,4 +1,4 @@
-import * as _ from 'lodash';
+import each from 'lodash/each';
 import 'mocha';
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';
@@ -32,7 +32,7 @@ describe('TokenRegistryWrapper', () => {
             expect(tokens).to.have.lengthOf(TOKEN_REGISTRY_SIZE_AFTER_MIGRATION);
 
             const schemaValidator = new SchemaValidator();
-            _.each(tokens, token => {
+            each(tokens, token => {
                 const validationResult = schemaValidator.validate(token, tokenSchema);
                 expect(validationResult.errors).to.have.lengthOf(0);
             });

--- a/test/token_registry_wrapper_test.ts
+++ b/test/token_registry_wrapper_test.ts
@@ -1,4 +1,4 @@
-import each from 'lodash/each';
+import each = require('lodash/each');
 import 'mocha';
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';

--- a/test/utils/order_factory.ts
+++ b/test/utils/order_factory.ts
@@ -1,4 +1,5 @@
-import * as _ from 'lodash';
+import assign from 'lodash/assign';
+import isUndefined from 'lodash/isUndefined';
 import * as BigNumber from 'bignumber.js';
 import {ZeroEx, SignedOrder} from '../../src';
 
@@ -16,7 +17,7 @@ export const orderFactory = {
         feeRecipient: string,
         expirationUnixTimestampSec?: BigNumber.BigNumber): Promise<SignedOrder> {
         const defaultExpirationUnixTimestampSec = new BigNumber(2524604400); // Close to infinite
-        expirationUnixTimestampSec = _.isUndefined(expirationUnixTimestampSec) ?
+        expirationUnixTimestampSec = isUndefined(expirationUnixTimestampSec) ?
             defaultExpirationUnixTimestampSec :
             expirationUnixTimestampSec;
         const order = {
@@ -34,7 +35,7 @@ export const orderFactory = {
         };
         const orderHash = await zeroEx.getOrderHashHexAsync(order);
         const ecSignature = await zeroEx.signOrderHashAsync(orderHash, maker);
-        const signedOrder: SignedOrder = _.assign(order, {ecSignature});
+        const signedOrder: SignedOrder = assign(order, {ecSignature});
         return signedOrder;
     },
 };

--- a/test/utils/order_factory.ts
+++ b/test/utils/order_factory.ts
@@ -1,5 +1,5 @@
-import assign from 'lodash/assign';
-import isUndefined from 'lodash/isUndefined';
+import assign = require('lodash/assign');
+import isUndefined = require('lodash/isUndefined');
 import * as BigNumber from 'bignumber.js';
 import {ZeroEx, SignedOrder} from '../../src';
 

--- a/test/utils/token_utils.ts
+++ b/test/utils/token_utils.ts
@@ -1,6 +1,6 @@
-import find from 'lodash/find';
-import filter from 'lodash/filter';
-import isUndefined from 'lodash/isUndefined';
+import find = require('lodash/find');
+import filter = require('lodash/filter');
+import isUndefined = require('lodash/isUndefined');
 import {Token, ZeroExError} from '../../src';
 
 const PROTOCOL_TOKEN_SYMBOL = 'ZRX';

--- a/test/utils/token_utils.ts
+++ b/test/utils/token_utils.ts
@@ -1,4 +1,6 @@
-import * as _ from 'lodash';
+import find from 'lodash/find';
+import filter from 'lodash/filter';
+import isUndefined from 'lodash/isUndefined';
 import {Token, ZeroExError} from '../../src';
 
 const PROTOCOL_TOKEN_SYMBOL = 'ZRX';
@@ -9,14 +11,14 @@ export class TokenUtils {
         this.tokens = tokens;
     }
     public getProtocolTokenOrThrow(): Token {
-        const zrxToken = _.find(this.tokens, {symbol: PROTOCOL_TOKEN_SYMBOL});
-        if (_.isUndefined(zrxToken)) {
+        const zrxToken = find(this.tokens, {symbol: PROTOCOL_TOKEN_SYMBOL});
+        if (isUndefined(zrxToken)) {
             throw new Error(ZeroExError.ZRX_NOT_IN_TOKEN_REGISTRY);
         }
         return zrxToken;
     }
     public getNonProtocolTokens(): Token[] {
-        const nonProtocolTokens = _.filter(this.tokens, token => {
+        const nonProtocolTokens = filter(this.tokens, token => {
             return token.symbol !== PROTOCOL_TOKEN_SYMBOL;
         });
         return nonProtocolTokens;

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,6 +8,7 @@
     "declaration": true,
     "noImplicitAny": true,
     "experimentalDecorators": true,
+    "allowSyntheticDefaultImports": true,
     "strictNullChecks": true
   },
   "include": [

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -8,7 +8,6 @@
     "declaration": true,
     "noImplicitAny": true,
     "experimentalDecorators": true,
-    "allowSyntheticDefaultImports": true,
     "strictNullChecks": true
   },
   "include": [


### PR DESCRIPTION
This PR:
* reduces bundle size 2.61 -> 2.33 MB (821 -> 794 kB minified)
* introduces other import format for lodash
Source: https://stackoverflow.com/a/39415662/3546986