### PR TITLE
Testrpc snapshots

### DIFF
--- a/circle.yml
+++ b/circle.yml
@@ -1,13 +1,15 @@
 machine:
   node:
     version: 6.1.0
+  environment:
+      CONTRACTS_COMMIT: cd04d7c
 
 test:
   override:
-    - npm run testrpc:
+    - wget https://s3.amazonaws.com/testrpc-shapshots/${CONTRACTS_COMMIT}.zip
+    - unzip ${CONTRACTS_COMMIT}.zip -d testrpc_snapshot
+    - npm run testrpc -- --db testrpc_snapshot:
         background: true
-    - git clone git@github.com:0xProject/contracts.git ../contracts
-    - cd ../contracts; git checkout cd04d7c; npm install && npm run migrate
     - npm run test:coverage
     - npm run report_test_coverage
     - npm run test:umd

--- a/circle.yml
+++ b/circle.yml
@@ -2,12 +2,12 @@ machine:
   node:
     version: 6.1.0
   environment:
-      CONTRACTS_COMMIT: cd04d7c
+      CONTRACTS_COMMIT_HASH: cd04d7c
 
 test:
   override:
-    - wget https://s3.amazonaws.com/testrpc-shapshots/${CONTRACTS_COMMIT}.zip
-    - unzip ${CONTRACTS_COMMIT}.zip -d testrpc_snapshot
+    - wget https://s3.amazonaws.com/testrpc-shapshots/${CONTRACTS_COMMIT_HASH}.zip
+    - unzip ${CONTRACTS_COMMIT_HASH}.zip -d testrpc_snapshot
     - npm run testrpc -- --db testrpc_snapshot:
         background: true
     - npm run test:coverage

--- a/package.json
+++ b/package.json
@@ -14,7 +14,7 @@
   "scripts": {
     "prebuild": "npm run clean",
     "build": "run-p build:*:prod",
-    "prepublish": "run-p build:umd:prod build:commonjs:dev",
+    "prepublishOnly": "run-p build:umd:prod build:commonjs:dev",
     "postpublish": "run-s release docs:json upload_docs_json",
     "release": "publish-release --assets _bundles/index.js,_bundles/index.min.js",
     "upload_docs_json": "aws s3 cp docs/index.json s3://0xjs-docs-jsons/$(git describe --tags).json --profile 0xproject --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers --content-type aplication/json",


### PR DESCRIPTION
This PR:
* Starts using testrpc snapshots in CI builds, which speeds them up https://quip.com/RAMmADOXkqYB
* Changes prepublish script to prepublishOnly https://iamakulov.com/notes/npm-4-prepublish/

Those changes speed up an average test run from 8mins to 5mins.