### PR TITLE
Moves exchange contract address getters to zeroEx top level

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+v0.9.0 - TBD
+------------------------
+    * Move `zeroEx.exchange.getAvailableContractAddressesAsync` to `zeroEx.getAvailableExchangeContractAddressesAsync` (#94)
+    * Move `zeroEx.exchange.getProxyAuthorizedContractAddressesAsync` to `zeroEx.getProxyAuthorizedExchangeContractAddressesAsync` (#94)
+
 v0.8.0 - _Jul. 4, 2017_
 ------------------------
     * Add the ability to call methods on different authorized versions of the Exchange smart contract (#82)

--- a/src/0x.ts
+++ b/src/0x.ts
@@ -286,15 +286,11 @@ export class ZeroEx {
         const exchangeContractAddresses = await this.getAvailableExchangeContractAddressesAsync();
         const proxyAuthorizedExchangeContractAddresses = [];
         for (const exchangeContractAddress of exchangeContractAddresses) {
-            const isAuthorized = await this._isExchangeContractAddressProxyAuthorizedAsync(exchangeContractAddress);
+            const isAuthorized = await this.proxy.isAuthorizedAsync(exchangeContractAddress);
             if (isAuthorized) {
                 proxyAuthorizedExchangeContractAddresses.push(exchangeContractAddress);
             }
         }
         return proxyAuthorizedExchangeContractAddresses;
-    }
-    private async _isExchangeContractAddressProxyAuthorizedAsync(exchangeContractAddress: string): Promise<boolean> {
-        const isAuthorized = await this.proxy.isAuthorizedAsync(exchangeContractAddress);
-        return isAuthorized;
     }
 }

--- a/src/0x.ts
+++ b/src/0x.ts
@@ -164,7 +164,7 @@ export class ZeroEx {
         this.etherToken = new EtherTokenWrapper(this._web3Wrapper, this.token);
     }
     /**
-     * Sets a new provider for the web3 instance used by 0x.js. Updating the provider will stop all
+     * Sets a new web3 provider for 0x.js. Updating the provider will stop all
      * subscriptions so you will need to re-subscribe to all events relevant to your app after this call.
      * @param   provider    The Web3Provider you would like the 0x.js library to use from now on.
      */
@@ -177,7 +177,7 @@ export class ZeroEx {
         (this.etherToken as any)._invalidateContractInstance();
     }
     /**
-     * Get user Ethereum addresses available through the supplied web3 instance available for sending transactions.
+     * Get user Ethereum addresses available through the supplied web3 provider available for sending transactions.
      * @return  An array of available user Ethereum addresses.
      */
     public async getAvailableAddressesAsync(): Promise<string[]> {
@@ -257,7 +257,8 @@ export class ZeroEx {
     }
     /**
      * Returns the ethereum addresses of all available exchange contracts
-     * on the network that the provided web3 instance is connected to
+     * supported by this library on the network that the supplied web3
+     * provider is connected to
      * @return  The ethereum addresses of all available exchange contracts.
      */
     public async getAvailableExchangeContractAddressesAsync(): Promise<string[]> {
@@ -277,8 +278,8 @@ export class ZeroEx {
     }
     /**
      * Returns the ethereum addresses of all available exchange contracts
-     * on the network that the provided web3 instance is connected to
-     * that are currently authorized on the Proxy contract
+     * supported by this library on the network that the supplied web3
+     * provider is connected to that are currently authorized by the Proxy contract
      * @return  The ethereum addresses of all available and authorized exchange contract.
      */
     public async getProxyAuthorizedExchangeContractAddressesAsync(): Promise<string[]> {

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -43,12 +43,12 @@ export const assert = {
         assert.isETHAddressHex(variableName, senderAddressHex);
         const isSenderAddressAvailable = await web3Wrapper.isSenderAddressAvailableAsync(senderAddressHex);
         assert.assert(isSenderAddressAvailable,
-            `Specified ${variableName} ${senderAddressHex} isn't available through the supplied web3 instance`,
+            `Specified ${variableName} ${senderAddressHex} isn't available through the supplied web3 provider`,
         );
     },
     async isUserAddressAvailableAsync(web3Wrapper: Web3Wrapper): Promise<void> {
         const availableAddresses = await web3Wrapper.getAvailableAddressesAsync();
-        this.assert(!_.isEmpty(availableAddresses), 'No addresses were available on the provided web3 instance');
+        this.assert(!_.isEmpty(availableAddresses), 'No addresses were available on the provided web3 provider');
     },
     hasAtMostOneUniqueValue(value: any[], errMsg: string): void {
         this.assert(_.uniq(value).length <= 1, errMsg);

--- a/test/0x.js_test.ts
+++ b/test/0x.js_test.ts
@@ -33,7 +33,7 @@ describe('ZeroEx library', () => {
             expect((zeroEx.exchange as any)._exchangeContractByAddress[exchangeContractAddress]).to.be.undefined();
             expect((zeroEx.tokenRegistry as any)._tokenRegistryContractIfExists).to.be.undefined();
 
-            // Check that all nested web3 instances return the updated provider
+            // Check that all nested web3 wrapper instances return the updated provider
             const nestedWeb3WrapperProvider = (zeroEx as any)._web3Wrapper.getCurrentProvider();
             expect((nestedWeb3WrapperProvider as any).zeroExTestId).to.be.a('number');
             const exchangeWeb3WrapperProvider = (zeroEx.exchange as any)._web3Wrapper.getCurrentProvider();

--- a/test/0x.js_test.ts
+++ b/test/0x.js_test.ts
@@ -6,17 +6,18 @@ import * as BigNumber from 'bignumber.js';
 import * as Sinon from 'sinon';
 import {ZeroEx, Order} from '../src';
 import {constants} from './utils/constants';
+import {assert} from '../src/utils/assert';
 import {web3Factory} from './utils/web3_factory';
 
 chaiSetup.configure();
 const expect = chai.expect;
 
 describe('ZeroEx library', () => {
+    const web3 = web3Factory.create();
+    const zeroEx = new ZeroEx(web3.currentProvider);
     describe('#setProvider', () => {
         it('overrides provider in nested web3s and invalidates contractInstances', async () => {
-            const web3 = web3Factory.create();
-            const zeroEx = new ZeroEx(web3.currentProvider);
-            const [exchangeContractAddress] = await zeroEx.exchange.getAvailableContractAddressesAsync();
+            const [exchangeContractAddress] = await zeroEx.getAvailableExchangeContractAddressesAsync();
             // Instantiate the contract instances with the current provider
             await (zeroEx.exchange as any)._getExchangeContractAsync(exchangeContractAddress);
             await (zeroEx.tokenRegistry as any)._getTokenRegistryContractAsync();
@@ -51,11 +52,9 @@ describe('ZeroEx library', () => {
             s: '0x40349190569279751135161d22529dc25add4f6069af05be04cacbda2ace2254',
         };
         const address = '0x5409ed021d9299bf6814279a6a1411a7e866a631';
-        const web3 = web3Factory.create();
-        const zeroEx = new ZeroEx(web3.currentProvider);
         let exchangeContractAddress: string;
         before(async () => {
-            [exchangeContractAddress] = await zeroEx.exchange.getAvailableContractAddressesAsync();
+            [exchangeContractAddress] = await zeroEx.getAvailableExchangeContractAddressesAsync();
         });
         it('should return false if the data doesn\'t pertain to the signature & address', async () => {
             expect(ZeroEx.isValidSignature('0x0', signature, address)).to.be.false();
@@ -148,9 +147,6 @@ describe('ZeroEx library', () => {
             expirationUnixTimestampSec: new BigNumber(0),
         };
         it('calculates the order hash', async () => {
-            const web3 = web3Factory.create();
-            const zeroEx = new ZeroEx(web3.currentProvider);
-
             const orderHash = zeroEx.getOrderHashHex(order);
             expect(orderHash).to.be.equal(expectedOrderHash);
         });
@@ -158,8 +154,6 @@ describe('ZeroEx library', () => {
     describe('#signOrderHashAsync', () => {
         let stubs: Sinon.SinonStub[] = [];
         let makerAddress: string;
-        const web3 = web3Factory.create();
-        const zeroEx = new ZeroEx(web3.currentProvider);
         before(async () => {
             const availableAddreses = await zeroEx.getAvailableAddressesAsync();
             makerAddress = availableAddreses[0];
@@ -220,6 +214,24 @@ describe('ZeroEx library', () => {
 
             const ecSignature = await zeroEx.signOrderHashAsync(orderHash, makerAddress);
             expect(ecSignature).to.deep.equal(expectedECSignature);
+        });
+    });
+    describe('#getAvailableExchangeContractAddressesAsync', () => {
+        it('returns the exchange contract addresses', async () => {
+            const exchangeAddresses = await zeroEx.getAvailableExchangeContractAddressesAsync();
+            _.map(exchangeAddresses, exchangeAddress => {
+                assert.isETHAddressHex('exchangeAddress', exchangeAddress);
+            });
+        });
+    });
+    describe('#getProxyAuthorizedExchangeContractAddressesAsync', () => {
+        it('returns the Proxy authorized exchange contract addresses', async () => {
+            const exchangeAddresses = await zeroEx.getProxyAuthorizedExchangeContractAddressesAsync();
+            for (const exchangeAddress of exchangeAddresses) {
+                assert.isETHAddressHex('exchangeAddress', exchangeAddress);
+                const isAuthorized = await zeroEx.proxy.isAuthorizedAsync(exchangeAddress);
+                expect(isAuthorized).to.be.true();
+            }
         });
     });
 });

--- a/test/artifacts_test.ts
+++ b/test/artifacts_test.ts
@@ -27,7 +27,7 @@ describe('Artifacts', () => {
             await (zeroEx.token as any)._getProxyAddressAsync();
         }).timeout(TIMEOUT);
         it('exchange contract is deployed', async () => {
-            const exchangeContractAddresses = await zeroEx.exchange.getAvailableContractAddressesAsync();
+            const exchangeContractAddresses = await zeroEx.getAvailableExchangeContractAddressesAsync();
             expect(exchangeContractAddresses).to.have.lengthOf.above(0);
         }).timeout(TIMEOUT);
     });

--- a/test/assert_test.ts
+++ b/test/assert_test.ts
@@ -21,7 +21,7 @@ describe('Assertion library', () => {
             const varName = 'address';
             return expect(assert.isSenderAddressAsync(varName, validUnrelatedAddress, (zeroEx as any)._web3Wrapper))
                 .to.be.rejectedWith(
-                    `Specified ${varName} ${validUnrelatedAddress} isn't available through the supplied web3 instance`,
+                    `Specified ${varName} ${validUnrelatedAddress} isn't available through the supplied web3 provider`,
                 );
         });
         it('doesn\'t throw if address is available', async () => {

--- a/test/exchange_wrapper_test.ts
+++ b/test/exchange_wrapper_test.ts
@@ -44,7 +44,7 @@ describe('ExchangeWrapper', () => {
     before(async () => {
         web3 = web3Factory.create();
         zeroEx = new ZeroEx(web3.currentProvider);
-        [exchangeContractAddress] = await zeroEx.exchange.getAvailableContractAddressesAsync();
+        [exchangeContractAddress] = await zeroEx.getAvailableExchangeContractAddressesAsync();
         userAddresses = await promisify(web3.eth.getAccounts)();
         tokens = await zeroEx.tokenRegistry.getTokensAsync();
         tokenUtils = new TokenUtils(tokens);
@@ -817,24 +817,6 @@ describe('ExchangeWrapper', () => {
             const orderHashFromContract = await (zeroEx.exchange as any)
                 ._getOrderHashHexUsingContractCallAsync(signedOrder);
             expect(orderHash).to.equal(orderHashFromContract);
-        });
-    });
-    describe('#getAvailableContractAddressesAsync', () => {
-        it('returns the exchange contract addresses', async () => {
-            const exchangeAddresses = await zeroEx.exchange.getAvailableContractAddressesAsync();
-            _.map(exchangeAddresses, exchangeAddress => {
-                assert.isETHAddressHex('exchangeAddress', exchangeAddress);
-            });
-        });
-    });
-    describe('#getProxyAuthorizedContractAddressesAsync', () => {
-        it('returns the Proxy authorized exchange contract addresses', async () => {
-            const exchangeAddresses = await zeroEx.exchange.getProxyAuthorizedContractAddressesAsync();
-            for (const exchangeAddress of exchangeAddresses) {
-                assert.isETHAddressHex('exchangeAddress', exchangeAddress);
-                const isAuthorized = await zeroEx.proxy.isAuthorizedAsync(exchangeAddress);
-                expect(isAuthorized).to.be.true();
-            }
         });
     });
 });

--- a/test/proxy_wrapper_test.ts
+++ b/test/proxy_wrapper_test.ts
@@ -13,7 +13,7 @@ describe('ProxyWrapper', () => {
     before(async () => {
         const web3 = web3Factory.create();
         zeroEx = new ZeroEx(web3.currentProvider);
-        [exchangeContractAddress] = await zeroEx.exchange.getAvailableContractAddressesAsync();
+        [exchangeContractAddress] = await zeroEx.getAvailableExchangeContractAddressesAsync();
     });
     describe('#isAuthorizedAsync', () => {
         it('should return false if the address is not authorized', async () => {


### PR DESCRIPTION
* Moves `zeroEx.exchange.getAvailableContractAddressesAsync` to `zeroEx.getAvailableExchangeContractAddressesAsync`
* Moves `zeroEx.exchange.getProxyAuthorizedContractAddressesAsync` to `zeroEx.getProxyAuthorizedExchangeContractAddressesAsync`