### PR TITLE
Jsonschema types

### DIFF
--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -26,6 +26,54 @@ declare namespace Chai {
 }
 /* tslint:enable */
 
+// jsonschema declarations
+declare interface Schema {
+    id?: string;
+    $schema?: string;
+    title?: string;
+    description?: string;
+    multipleOf?: number;
+    maximum?: number;
+    exclusiveMaximum?: boolean;
+    minimum?: number;
+    exclusiveMinimum?: boolean;
+    maxLength?: number;
+    minLength?: number;
+    pattern?: string;
+    additionalItems?: boolean | Schema;
+    items?: Schema | Schema[];
+    maxItems?: number;
+    minItems?: number;
+    uniqueItems?: boolean;
+    maxProperties?: number;
+    minProperties?: number;
+    required?: string[];
+    additionalProperties?: boolean | Schema;
+    definitions?: {
+        [name: string]: Schema;
+    };
+    properties?: {
+        [name: string]: Schema;
+    };
+    patternProperties?: {
+        [name: string]: Schema;
+    };
+    dependencies?: {
+        [name: string]: Schema | string[];
+    };
+    'enum'?: any[];
+    type?: string | string[];
+    allOf?: Schema[];
+    anyOf?: Schema[];
+    oneOf?: Schema[];
+    not?: Schema;
+    // This is the only property that's not defined in https://github.com/tdegrunt/jsonschema/blob/master/lib/index.d.ts
+    // There is an open issue for that: https://github.com/tdegrunt/jsonschema/issues/194
+    // There is also an opened PR: https://github.com/tdegrunt/jsonschema/pull/218/files
+    // As soon as it gets merged we should be good to use types from 'jsonschema' package
+    $ref?: string;
+}
+
 declare module '*.json' {
     const json: any;
     /* tslint:disable */

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -27,6 +27,7 @@ declare namespace Chai {
 /* tslint:enable */
 
 // jsonschema declarations
+// Source: https://github.com/tdegrunt/jsonschema/blob/master/lib/index.d.ts
 declare interface Schema {
     id?: string;
     $schema?: string;

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -2,7 +2,6 @@ import * as _ from 'lodash';
 import * as BigNumber from 'bignumber.js';
 import * as Web3 from 'web3';
 import {Web3Wrapper} from '../web3_wrapper';
-import {Schema} from 'jsonschema';
 import {SchemaValidator} from './schema_validator';
 import {utils} from './utils';
 import {StringEnum} from '../types';

--- a/src/utils/schema_validator.ts
+++ b/src/utils/schema_validator.ts
@@ -1,4 +1,4 @@
-import {Validator, ValidatorResult,  Schema} from 'jsonschema';
+import {Validator, ValidatorResult, Schema as JSONSchema} from 'jsonschema';
 import {ecSignatureSchema, ecSignatureParameterSchema} from '../schemas/ec_signature_schema';
 import {orderHashSchema} from '../schemas/order_hash_schema';
 import {orderSchema, signedOrderSchema} from '../schemas/order_schemas';
@@ -12,18 +12,18 @@ export class SchemaValidator {
     private validator: Validator;
     constructor() {
         this.validator = new Validator();
-        this.validator.addSchema(tokenSchema, tokenSchema.id);
-        this.validator.addSchema(orderSchema, orderSchema.id);
-        this.validator.addSchema(numberSchema, numberSchema.id);
-        this.validator.addSchema(addressSchema, addressSchema.id);
-        this.validator.addSchema(orderHashSchema, orderHashSchema.id);
-        this.validator.addSchema(blockParamSchema, blockParamSchema.id);
-        this.validator.addSchema(ecSignatureSchema, ecSignatureSchema.id);
-        this.validator.addSchema(signedOrderSchema, signedOrderSchema.id);
-        this.validator.addSchema(subscriptionOptsSchema, subscriptionOptsSchema.id);
-        this.validator.addSchema(indexFilterValuesSchema, indexFilterValuesSchema.id);
-        this.validator.addSchema(ecSignatureParameterSchema, ecSignatureParameterSchema.id);
-        this.validator.addSchema(orderFillOrKillRequestsSchema, orderFillOrKillRequestsSchema.id);
+        this.validator.addSchema(tokenSchema as JSONSchema, tokenSchema.id);
+        this.validator.addSchema(orderSchema as JSONSchema, orderSchema.id);
+        this.validator.addSchema(numberSchema as JSONSchema, numberSchema.id);
+        this.validator.addSchema(addressSchema as JSONSchema, addressSchema.id);
+        this.validator.addSchema(orderHashSchema as JSONSchema, orderHashSchema.id);
+        this.validator.addSchema(blockParamSchema as JSONSchema, blockParamSchema.id);
+        this.validator.addSchema(ecSignatureSchema as JSONSchema, ecSignatureSchema.id);
+        this.validator.addSchema(signedOrderSchema as JSONSchema, signedOrderSchema.id);
+        this.validator.addSchema(subscriptionOptsSchema as JSONSchema, subscriptionOptsSchema.id);
+        this.validator.addSchema(indexFilterValuesSchema as JSONSchema, indexFilterValuesSchema.id);
+        this.validator.addSchema(ecSignatureParameterSchema as JSONSchema, ecSignatureParameterSchema.id);
+        this.validator.addSchema(orderFillOrKillRequestsSchema as JSONSchema, orderFillOrKillRequestsSchema.id);
     }
     // In order to validate a complex JS object using jsonschema, we must replace any complex
     // sub-types (e.g BigNumber) with a simpler string representation. Since BigNumber and other


### PR DESCRIPTION
This PR:
* Fixes failing tests because the jsonschema type definitions does not have `$ref` field

I don't know, why it was not failing before.