### PR TITLE
Remove unnecessary assertions & add regression tests

### DIFF
--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -711,7 +711,6 @@ export class ExchangeWrapper extends ContractWrapper {
     private async _isRoundingErrorAsync(numerator: BigNumber.BigNumber,
                                         demoninator: BigNumber.BigNumber,
                                         makerTokenAmount: BigNumber.BigNumber): Promise<boolean> {
-        await assert.isUserAddressAvailableAsync(this._web3Wrapper);
         const exchangeInstance = await this._getExchangeContractAsync();
         const isRoundingError = await exchangeInstance.isRoundingError.call(
             demoninator, numerator, makerTokenAmount,

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -45,7 +45,6 @@ export class TokenWrapper extends ContractWrapper {
     public async getBalanceAsync(tokenAddress: string, ownerAddress: string): Promise<BigNumber.BigNumber> {
         assert.isETHAddressHex('ownerAddress', ownerAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
-        await assert.isUserAddressAvailableAsync(this._web3Wrapper);
 
         const tokenContract = await this._getTokenContractAsync(tokenAddress);
         let balance = await tokenContract.balanceOf.call(ownerAddress);

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -89,7 +89,6 @@ export class TokenWrapper extends ContractWrapper {
     public async getAllowanceAsync(tokenAddress: string, ownerAddress: string, spenderAddress: string) {
         assert.isETHAddressHex('ownerAddress', ownerAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
-        await assert.isUserAddressAvailableAsync(this._web3Wrapper);
 
         const tokenContract = await this._getTokenContractAsync(tokenAddress);
         let allowanceInBaseUnits = await tokenContract.allowance.call(ownerAddress, spenderAddress);

--- a/src/subproviders/empty_wallet_subprovider.ts
+++ b/src/subproviders/empty_wallet_subprovider.ts
@@ -1,0 +1,25 @@
+import * as _ from 'lodash';
+import Web3 = require('web3');
+
+/*
+ * This class implements the web3-provider-engine subprovider interface and returns
+ * that the provider has no addresses when queried.
+ * Source: https://github.com/MetaMask/provider-engine/blob/master/subproviders/subprovider.js
+ */
+export class EmptyWalletSubProvider {
+    public handleRequest(payload: any, next: () => void, end: (err: Error|null, result: any) => void) {
+        switch (payload.method) {
+            case 'eth_accounts':
+                end(null, []);
+                return;
+
+            default:
+                next();
+                return;
+        }
+    }
+    // Required to implement this method despite not needing it for this subprovider
+    public setEngine(engine: any) {
+        // noop
+    }
+}

--- a/src/subproviders/empty_wallet_subprovider.ts
+++ b/src/subproviders/empty_wallet_subprovider.ts
@@ -1,5 +1,5 @@
-import * as _ from 'lodash';
-import Web3 = require('web3');
+import * as Web3 from 'web3';
+import {JSONRPCPayload} from '../types';
 
 /*
  * This class implements the web3-provider-engine subprovider interface and returns
@@ -7,7 +7,7 @@ import Web3 = require('web3');
  * Source: https://github.com/MetaMask/provider-engine/blob/master/subproviders/subprovider.js
  */
 export class EmptyWalletSubProvider {
-    public handleRequest(payload: any, next: () => void, end: (err: Error|null, result: any) => void) {
+    public handleRequest(payload: JSONRPCPayload, next: () => void, end: (err: Error|null, result: any) => void) {
         switch (payload.method) {
             case 'eth_accounts':
                 end(null, []);

--- a/src/types.ts
+++ b/src/types.ts
@@ -368,3 +368,8 @@ export interface ContractArtifact {
         };
     };
 }
+
+export interface JSONRPCPayload {
+    params: any[];
+    method: string;
+}

--- a/test/token_wrapper_test.ts
+++ b/test/token_wrapper_test.ts
@@ -176,7 +176,6 @@ describe('TokenWrapper', () => {
             before(async () => {
                 const hasAddresses = false;
                 const web3WithoutAccounts = web3Factory.create(hasAddresses);
-                web3WithoutAccounts.eth.getAccounts(console.log);
                 zeroExWithoutAccounts = new ZeroEx(web3WithoutAccounts.currentProvider);
             });
             it('should return balance even when called with Web3 provider instance without addresses', async () => {
@@ -208,25 +207,49 @@ describe('TokenWrapper', () => {
         });
     });
     describe('#getAllowanceAsync', () => {
-        it('should get the proxy allowance', async () => {
-            const token = tokens[0];
-            const ownerAddress = coinbase;
-            const spenderAddress = addressWithoutFunds;
+        describe('With web3 provider with accounts', () => {
+            it('should get the proxy allowance', async () => {
+                const token = tokens[0];
+                const ownerAddress = coinbase;
+                const spenderAddress = addressWithoutFunds;
 
-            const amountInBaseUnits = new BigNumber(50);
-            await zeroEx.token.setAllowanceAsync(token.address, ownerAddress, spenderAddress, amountInBaseUnits);
+                const amountInBaseUnits = new BigNumber(50);
+                await zeroEx.token.setAllowanceAsync(token.address, ownerAddress, spenderAddress, amountInBaseUnits);
 
-            const allowance = await zeroEx.token.getAllowanceAsync(token.address, ownerAddress, spenderAddress);
-            const expectedAllowance = amountInBaseUnits;
-            return expect(allowance).to.be.bignumber.equal(expectedAllowance);
+                const allowance = await zeroEx.token.getAllowanceAsync(token.address, ownerAddress, spenderAddress);
+                const expectedAllowance = amountInBaseUnits;
+                return expect(allowance).to.be.bignumber.equal(expectedAllowance);
+            });
+            it('should return 0 if no allowance set yet', async () => {
+                const token = tokens[0];
+                const ownerAddress = coinbase;
+                const spenderAddress = addressWithoutFunds;
+                const allowance = await zeroEx.token.getAllowanceAsync(token.address, ownerAddress, spenderAddress);
+                const expectedAllowance = new BigNumber(0);
+                return expect(allowance).to.be.bignumber.equal(expectedAllowance);
+            });
         });
-        it('should return 0 if no allowance set yet', async () => {
-            const token = tokens[0];
-            const ownerAddress = coinbase;
-            const spenderAddress = addressWithoutFunds;
-            const allowance = await zeroEx.token.getAllowanceAsync(token.address, ownerAddress, spenderAddress);
-            const expectedAllowance = new BigNumber(0);
-            return expect(allowance).to.be.bignumber.equal(expectedAllowance);
+        describe('With web3 provider without accounts', () => {
+            let zeroExWithoutAccounts: ZeroEx;
+            before(async () => {
+                const hasAddresses = false;
+                const web3WithoutAccounts = web3Factory.create(hasAddresses);
+                zeroExWithoutAccounts = new ZeroEx(web3WithoutAccounts.currentProvider);
+            });
+            it('should get the proxy allowance', async () => {
+                const token = tokens[0];
+                const ownerAddress = coinbase;
+                const spenderAddress = addressWithoutFunds;
+
+                const amountInBaseUnits = new BigNumber(50);
+                await zeroEx.token.setAllowanceAsync(token.address, ownerAddress, spenderAddress, amountInBaseUnits);
+
+                const allowance = await zeroExWithoutAccounts.token.getAllowanceAsync(
+                    token.address, ownerAddress, spenderAddress,
+                );
+                const expectedAllowance = amountInBaseUnits;
+                return expect(allowance).to.be.bignumber.equal(expectedAllowance);
+            });
         });
     });
     describe('#getProxyAllowanceAsync', () => {

--- a/test/utils/web3_factory.ts
+++ b/test/utils/web3_factory.ts
@@ -16,7 +16,7 @@ export const web3Factory = {
         web3.setProvider(provider);
         return web3;
     },
-    getRpcProvider(hasAddresses: boolean): Web3.Provider {
+    getRpcProvider(hasAddresses: boolean = true): Web3.Provider {
         const provider = new ProviderEngine();
         const rpcUrl = `http://${constants.RPC_HOST}:${constants.RPC_PORT}`;
         if (!hasAddresses) {

--- a/test/utils/web3_factory.ts
+++ b/test/utils/web3_factory.ts
@@ -7,17 +7,21 @@ import ProviderEngine = require('web3-provider-engine');
 import RpcSubprovider = require('web3-provider-engine/subproviders/rpc');
 import * as Web3 from 'web3';
 import {constants} from './constants';
+import {EmptyWalletSubProvider} from '../../src/subproviders/empty_wallet_subprovider';
 
 export const web3Factory = {
-    create(): Web3 {
-        const provider = this.getRpcProvider();
+    create(hasAddresses: boolean = true): Web3 {
+        const provider = this.getRpcProvider(hasAddresses);
         const web3 = new Web3();
         web3.setProvider(provider);
         return web3;
     },
-    getRpcProvider(): Web3.Provider {
+    getRpcProvider(hasAddresses: boolean): Web3.Provider {
         const provider = new ProviderEngine();
         const rpcUrl = `http://${constants.RPC_HOST}:${constants.RPC_PORT}`;
+        if (!hasAddresses) {
+            provider.addProvider(new EmptyWalletSubProvider());
+        }
         provider.addProvider(new RpcSubprovider({
             rpcUrl,
         }));

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,9 +6,9 @@
   version "4.0.2"
   resolved "https://registry.yarnpkg.com/@types/bignumber.js/-/bignumber.js-4.0.2.tgz#22a16946c9faa9f2c9c0ad4c7c3734a3033320ae"
 
-"@types/fs-extra@^3.0.0":
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-3.0.3.tgz#1d66eb670ebf657e57c0fda014df340c19d8aa0c"
+"@types/fs-extra@^4.0.0":
+  version "4.0.0"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
   dependencies:
     "@types/node" "*"
 
@@ -1977,7 +1977,7 @@ form-data@~2.1.1:
     combined-stream "^1.0.5"
     mime-types "^2.1.12"
 
-formatio@1.2.0:
+formatio@1.2.0, formatio@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/formatio/-/formatio-1.2.0.tgz#f3b2167d9068c4698a8d51f4f760a39a54d818eb"
   dependencies:
@@ -2003,9 +2003,9 @@ fs-extra@^0.30.0:
     path-is-absolute "^1.0.0"
     rimraf "^2.2.8"
 
-fs-extra@^3.0.0:
-  version "3.0.1"
-  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-3.0.1.tgz#3794f378c58b342ea7dbbb23095109c4b3b62291"
+fs-extra@^4.0.0:
+  version "4.0.1"
+  resolved "https://registry.yarnpkg.com/fs-extra/-/fs-extra-4.0.1.tgz#7fc0c6c8957f983f57f306a24e5b9ddd8d0dd880"
   dependencies:
     graceful-fs "^4.1.2"
     jsonfile "^3.0.0"
@@ -2759,6 +2759,10 @@ jsprim@^1.2.2:
     json-schema "0.2.3"
     verror "1.3.6"
 
+just-extend@^1.1.22:
+  version "1.1.22"
+  resolved "https://registry.yarnpkg.com/just-extend/-/just-extend-1.1.22.tgz#3330af756cab6a542700c64b2e4e4aa062d52fff"
+
 keccak@^1.0.2:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/keccak/-/keccak-1.3.0.tgz#3681bd99ad3d0354ddb29b9040c1b6560cce08ac"
@@ -2956,6 +2960,10 @@ log-driver@1.2.5:
 lolex@^1.6.0:
   version "1.6.0"
   resolved "https://registry.yarnpkg.com/lolex/-/lolex-1.6.0.tgz#3a9a0283452a47d7439e72731b9e07d7386e49f6"
+
+lolex@^2.1.2:
+  version "2.1.2"
+  resolved "https://registry.yarnpkg.com/lolex/-/lolex-2.1.2.tgz#2694b953c9ea4d013e5b8bfba891c991025b2629"
 
 longest@^1.0.1:
   version "1.0.1"
@@ -3241,6 +3249,15 @@ nanomatch@^1.2.0:
 native-promise-only@^0.8.1:
   version "0.8.1"
   resolved "https://registry.yarnpkg.com/native-promise-only/-/native-promise-only-0.8.1.tgz#20a318c30cb45f71fe7adfbf7b21c99c1472ef11"
+
+nise@^1.0.1:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/nise/-/nise-1.0.1.tgz#0da92b10a854e97c0f496f6c2845a301280b3eef"
+  dependencies:
+    formatio "^1.2.0"
+    just-extend "^1.1.22"
+    lolex "^1.6.0"
+    path-to-regexp "^1.7.0"
 
 node-abi@^2.0.0:
   version "2.0.3"
@@ -4259,14 +4276,15 @@ single-line-log@^0.4.1:
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/single-line-log/-/single-line-log-0.4.1.tgz#87a55649f749d783ec0dcd804e8140d9873c7cee"
 
-sinon@^2.3.2:
-  version "2.3.6"
-  resolved "https://registry.yarnpkg.com/sinon/-/sinon-2.3.6.tgz#95378e7e0f976a9712e9b4591ff5b39e73dc3dde"
+sinon@^3.0.0:
+  version "3.2.0"
+  resolved "https://registry.yarnpkg.com/sinon/-/sinon-3.2.0.tgz#8848a66ab6e8b80b5532e3824f59f83ea2628c77"
   dependencies:
     diff "^3.1.0"
     formatio "1.2.0"
-    lolex "^1.6.0"
+    lolex "^2.1.2"
     native-promise-only "^0.8.1"
+    nise "^1.0.1"
     path-to-regexp "^1.7.0"
     samsam "^1.1.3"
     text-encoding "0.6.4"
@@ -4825,18 +4843,18 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
-typedoc@^0.7.1:
-  version "0.7.1"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.7.1.tgz#b441bffe246bb3e0e598d9ae474e743594bda769"
+typedoc@^0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.8.0.tgz#d7172bc6a29964f451b7609c005beadadefe2361"
   dependencies:
-    "@types/fs-extra" "^3.0.0"
+    "@types/fs-extra" "^4.0.0"
     "@types/handlebars" "^4.0.31"
     "@types/highlight.js" "^9.1.8"
     "@types/lodash" "^4.14.37"
     "@types/marked" "0.0.28"
     "@types/minimatch" "^2.0.29"
     "@types/shelljs" "^0.7.0"
-    fs-extra "^3.0.0"
+    fs-extra "^4.0.0"
     handlebars "^4.0.6"
     highlight.js "^9.0.0"
     lodash "^4.13.1"
@@ -4845,7 +4863,7 @@ typedoc@^0.7.1:
     progress "^2.0.0"
     shelljs "^0.7.0"
     typedoc-default-themes "^0.5.0"
-    typescript "2.3.2"
+    typescript "2.4.1"
 
 types-bn@^0.0.1:
   version "0.0.1"
@@ -4861,11 +4879,7 @@ types-ethereumjs-util@^0.0.5:
     buffer "^5.0.6"
     rlp "^2.0.0"
 
-typescript@2.3.2:
-  version "2.3.2"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.3.2.tgz#f0f045e196f69a72f06b25fd3bd39d01c3ce9984"
-
-typescript@^2.4.1:
+typescript@2.4.1, typescript@^2.4.1:
   version "2.4.1"
   resolved "https://registry.yarnpkg.com/typescript/-/typescript-2.4.1.tgz#c3ccb16ddaa0b2314de031e7e6fee89e5ba346bc"
 


### PR DESCRIPTION
This PR addresses https://github.com/0xProject/0x.js/issues/119

- Removes the unnecessary assertion that a user address must be available from three 0x.js methods:
    - `getBalanceAsync`
    - `getAllowanceAsync`
    - `_isRoundingErrorAsync`
- Added regression tests for `getBalanceAsync` and `getAllowanceAsync` to ensure this type of error does not re-occur. This was also an opportunity to support writing tests with a web3 provider that does not have any addresses which will be used to make future tests more robust.
