### PR TITLE
Add implementation for public order validation functions

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,10 +1,14 @@
 # CHANGELOG
 
-v0.9.4 - _TBD_
+v0.10.0 - _TBD_
 ------------------------
+    * Added `zeroEx.exchange.validateFillOrderAndThrowIfInvalidAsync` (#128)
+    * Added `zeroEx.exchange.validateFillOrKillOrderAndThrowIfInvalidAsync` (#128)
+    * Added `zeroEx.exchange.validateCancelOrderAndThrowIfInvalidAsync` (#128)
+    * Added `zeroEx.exchange.isRoundingError` (#128)
+    * Add `zeroEx.proxy.getContractAddressAsync` to public interface (#130)
     * Add clear error message when checksummed address is passed to a public method (#124)
     * Fixes the description of `shouldThrowOnInsufficientBalanceOrAllowance` in docs (#127)
-    * Add `zeroEx.proxy.getContractAddressAsync` to public interface (#130)
 
 v0.9.3 - _Aug 22, 2017_
 ------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,10 @@
 
 v0.10.0 - _TBD_
 ------------------------
-    * Added `zeroEx.exchange.validateFillOrderAndThrowIfInvalidAsync` (#128)
-    * Added `zeroEx.exchange.validateFillOrKillOrderAndThrowIfInvalidAsync` (#128)
-    * Added `zeroEx.exchange.validateCancelOrderAndThrowIfInvalidAsync` (#128)
-    * Added `zeroEx.exchange.isRoundingError` (#128)
-    * Add `zeroEx.proxy.getContractAddressAsync` to public interface (#130)
+    * Added `zeroEx.exchange.validateFillOrderThrowIfInvalidAsync` (#128)
+    * Added `zeroEx.exchange.validateFillOrKillOrderThrowIfInvalidAsync` (#128)
+    * Added `zeroEx.exchange.validateCancelOrderThrowIfInvalidAsync` (#128)
+    * Added `zeroEx.exchange.isRoundingErrorAsync` (#128)
     * Add clear error message when checksummed address is passed to a public method (#124)
     * Fixes the description of `shouldThrowOnInsufficientBalanceOrAllowance` in docs (#127)
 

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,7 +6,8 @@ v0.10.0 - _TBD_
     * Added `zeroEx.exchange.validateFillOrKillOrderThrowIfInvalidAsync` (#128)
     * Added `zeroEx.exchange.validateCancelOrderThrowIfInvalidAsync` (#128)
     * Added `zeroEx.exchange.isRoundingErrorAsync` (#128)
-    * Add clear error message when checksummed address is passed to a public method (#124)
+    * Added `zeroEx.proxy.getContractAddressAsync` (#130)
+    * Added clear error message when checksummed address is passed to a public method (#124)
     * Fixes the description of `shouldThrowOnInsufficientBalanceOrAllowance` in docs (#127)
 
 v0.9.3 - _Aug 22, 2017_

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -161,7 +161,7 @@ export class ExchangeWrapper extends ContractWrapper {
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
 
         const exchangeInstance = await this._getExchangeContractAsync();
-        await this.validateFillOrderAndThrowIfInvalidAsync(signedOrder, fillTakerTokenAmount, takerAddress);
+        await this.validateFillOrderThrowIfInvalidAsync(signedOrder, fillTakerTokenAmount, takerAddress);
 
         const [orderAddresses, orderValues] = ExchangeWrapper._getOrderAddressesAndValues(signedOrder);
 
@@ -226,7 +226,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.isBoolean('shouldThrowOnInsufficientBalanceOrAllowance', shouldThrowOnInsufficientBalanceOrAllowance);
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
         for (const signedOrder of signedOrders) {
-            await this.validateFillOrderAndThrowIfInvalidAsync(
+            await this.validateFillOrderThrowIfInvalidAsync(
                 signedOrder, fillTakerTokenAmount, takerAddress);
         }
         if (_.isEmpty(signedOrders)) {
@@ -311,7 +311,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.isBoolean('shouldThrowOnInsufficientBalanceOrAllowance', shouldThrowOnInsufficientBalanceOrAllowance);
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
         for (const orderFillRequest of orderFillRequests) {
-            await this.validateFillOrderAndThrowIfInvalidAsync(
+            await this.validateFillOrderThrowIfInvalidAsync(
                 orderFillRequest.signedOrder, orderFillRequest.takerTokenFillAmount, takerAddress);
         }
         if (_.isEmpty(orderFillRequests)) {
@@ -378,7 +378,7 @@ export class ExchangeWrapper extends ContractWrapper {
 
         const exchangeInstance = await this._getExchangeContractAsync();
 
-        await this.validateFillOrKillOrderAndThrowIfInvalidAsync(signedOrder, fillTakerTokenAmount, takerAddress);
+        await this.validateFillOrKillOrderThrowIfInvalidAsync(signedOrder, fillTakerTokenAmount, takerAddress);
 
         const [orderAddresses, orderValues] = ExchangeWrapper._getOrderAddressesAndValues(signedOrder);
 
@@ -430,7 +430,7 @@ export class ExchangeWrapper extends ContractWrapper {
         }
         const exchangeInstance = await this._getExchangeContractAsync();
         for (const request of orderFillOrKillRequests) {
-            await this.validateFillOrKillOrderAndThrowIfInvalidAsync(
+            await this.validateFillOrKillOrderThrowIfInvalidAsync(
                 request.signedOrder, request.fillTakerAmount, takerAddress);
         }
 
@@ -488,7 +488,7 @@ export class ExchangeWrapper extends ContractWrapper {
         await assert.isSenderAddressAsync('order.maker', order.maker, this._web3Wrapper);
 
         const exchangeInstance = await this._getExchangeContractAsync();
-        await this.validateCancelOrderAndThrowIfInvalidAsync(order, cancelTakerTokenAmount);
+        await this.validateCancelOrderThrowIfInvalidAsync(order, cancelTakerTokenAmount);
 
         const [orderAddresses, orderValues] = ExchangeWrapper._getOrderAddressesAndValues(order);
         const gas = await exchangeInstance.cancelOrder.estimateGas(
@@ -534,7 +534,7 @@ export class ExchangeWrapper extends ContractWrapper {
         const maker = makers[0];
         await assert.isSenderAddressAsync('maker', maker, this._web3Wrapper);
         for (const cancellationRequest of orderCancellationRequests) {
-            await this.validateCancelOrderAndThrowIfInvalidAsync(
+            await this.validateCancelOrderThrowIfInvalidAsync(
                 cancellationRequest.order, cancellationRequest.takerTokenCancelAmount,
             );
         }
@@ -634,14 +634,14 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   takerAddress            The user Ethereum address who would like to fill this order.
      *                                  Must be available via the supplied Web3.Provider passed to 0x.js.
      */
-    public async validateFillOrderAndThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                         fillTakerTokenAmount: BigNumber.BigNumber,
-                                                         takerAddress: string): Promise<void> {
+    public async validateFillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
+                                                      fillTakerTokenAmount: BigNumber.BigNumber,
+                                                      takerAddress: string): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, signedOrderSchema);
         assert.isBigNumber('fillTakerTokenAmount', fillTakerTokenAmount);
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
         const zrxTokenAddress = await this._getZRXTokenAddressAsync();
-        await this._orderValidationUtils.validateFillOrderAndThrowIfInvalidAsync(
+        await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
             signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }
     /**
@@ -650,13 +650,13 @@ export class ExchangeWrapper extends ContractWrapper {
      *                                  The order you would like to cancel.
      * @param   cancelTakerTokenAmount  The amount (specified in taker tokens) that you would like to cancel.
      */
-    public async validateCancelOrderAndThrowIfInvalidAsync(
+    public async validateCancelOrderThrowIfInvalidAsync(
         order: Order, cancelTakerTokenAmount: BigNumber.BigNumber): Promise<void> {
         assert.doesConformToSchema('order', order, orderSchema);
         assert.isBigNumber('cancelTakerTokenAmount', cancelTakerTokenAmount);
         const orderHash = utils.getOrderHashHex(order);
         const unavailableTakerTokenAmount = await this.getUnavailableTakerAmountAsync(orderHash);
-        await this._orderValidationUtils.validateCancelOrderAndThrowIfInvalidAsync(
+        await this._orderValidationUtils.validateCancelOrderThrowIfInvalidAsync(
             order, cancelTakerTokenAmount, unavailableTakerTokenAmount);
     }
     /**
@@ -667,14 +667,14 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   takerAddress            The user Ethereum address who would like to fill this order.
      *                                  Must be available via the supplied Web3.Provider passed to 0x.js.
      */
-    public async validateFillOrKillOrderAndThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                               fillTakerTokenAmount: BigNumber.BigNumber,
-                                                               takerAddress: string): Promise<void> {
+    public async validateFillOrKillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
+                                                            fillTakerTokenAmount: BigNumber.BigNumber,
+                                                            takerAddress: string): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, signedOrderSchema);
         assert.isBigNumber('fillTakerTokenAmount', fillTakerTokenAmount);
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
         const zrxTokenAddress = await this._getZRXTokenAddressAsync();
-        await this._orderValidationUtils.validateFillOrKillOrderAndThrowIfInvalidAsync(
+        await this._orderValidationUtils.validateFillOrKillOrderThrowIfInvalidAsync(
             signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }
     public async isRoundingErrorAsync(numerator: BigNumber.BigNumber,

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -645,7 +645,7 @@ export class ExchangeWrapper extends ContractWrapper {
             signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }
     /**
-     * Checks if order cancel will succeed and throws an error otherwise.
+     * Checks if cancelling a given order will succeed and throws an informative error if it won't.
      * @param   order                   An object that conforms to the Order or SignedOrder interface.
      *                                  The order you would like to cancel.
      * @param   cancelTakerTokenAmount  The amount (specified in taker tokens) that you would like to cancel.
@@ -660,7 +660,7 @@ export class ExchangeWrapper extends ContractWrapper {
             order, cancelTakerTokenAmount, unavailableTakerTokenAmount);
     }
     /**
-     * Checks if fillOrKill order will succeed and throws an error otherwise.
+     * Checks if calling fillOrKill on a given order will succeed and throws an informative error if it won't.
      * @param   signedOrder             An object that conforms to the SignedOrder interface. The
      *                                  signedOrder you wish to fill.
      * @param   fillTakerTokenAmount    The total amount of the takerTokens you would like to fill.
@@ -678,11 +678,13 @@ export class ExchangeWrapper extends ContractWrapper {
             signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }
     /**
-     * Checks if rounding error will be > 0.1%
-     * when computing makerTokenAmount by doing `(fillTakerTokenAmount * makerTokenAmount) / takerTokenAmount`
+     * Checks if rounding error will be > 0.1% when computing makerTokenAmount by doing:
+     * `(fillTakerTokenAmount * makerTokenAmount) / takerTokenAmount`.
+     * 0x Protocol does not accept any trades that result in large rounding errors. This means that tokens with few or
+     * no decimals can only be filled in quantities and ratios that avoid large rounding errors.
      * @param   fillTakerTokenAmount   The amount of the order (in taker tokens baseUnits) that you wish to fill.
      * @param   takerTokenAmount       The order size on the taker side
-     * @param   makerTokenAmount       The order size on the maker size
+     * @param   makerTokenAmount       The order size on the maker side
      */
     public async isRoundingErrorAsync(fillTakerTokenAmount: BigNumber.BigNumber,
                                       takerTokenAmount: BigNumber.BigNumber,

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -677,15 +677,22 @@ export class ExchangeWrapper extends ContractWrapper {
         await this._orderValidationUtils.validateFillOrKillOrderThrowIfInvalidAsync(
             signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }
-    public async isRoundingErrorAsync(numerator: BigNumber.BigNumber,
-                                      demoninator: BigNumber.BigNumber,
+    /**
+     * Checks if rounding error will be > 0.1%
+     * when computing makerTokenAmount by doing `(fillTakerTokenAmount * makerTokenAmount) / takerTokenAmount`
+     * @param   fillTakerTokenAmount   The amount of the order (in taker tokens baseUnits) that you wish to fill.
+     * @param   takerTokenAmount       The order size on the taker side
+     * @param   makerTokenAmount       The order size on the maker size
+     */
+    public async isRoundingErrorAsync(fillTakerTokenAmount: BigNumber.BigNumber,
+                                      takerTokenAmount: BigNumber.BigNumber,
                                       makerTokenAmount: BigNumber.BigNumber): Promise<boolean> {
-        assert.isBigNumber('numerator', numerator);
-        assert.isBigNumber('demoninator', demoninator);
+        assert.isBigNumber('fillTakerTokenAmount', fillTakerTokenAmount);
+        assert.isBigNumber('takerTokenAmount', takerTokenAmount);
         assert.isBigNumber('makerTokenAmount', makerTokenAmount);
         const exchangeInstance = await this._getExchangeContractAsync();
         const isRoundingError = await exchangeInstance.isRoundingError.call(
-            numerator, demoninator, makerTokenAmount,
+            fillTakerTokenAmount, takerTokenAmount, makerTokenAmount,
         );
         return isRoundingError;
     }

--- a/src/types.ts
+++ b/src/types.ts
@@ -180,6 +180,7 @@ export enum ExchangeContractErrs {
     OrderCancelExpired = 'ORDER_CANCEL_EXPIRED',
     OrderCancelAmountZero = 'ORDER_CANCEL_AMOUNT_ZERO',
     OrderAlreadyCancelledOrFilled = 'ORDER_ALREADY_CANCELLED_OR_FILLED',
+    OrderFillAmountZero = 'ORDER_FILL_AMOUNT_ZERO',
     OrderRemainingFillAmountZero = 'ORDER_REMAINING_FILL_AMOUNT_ZERO',
     OrderFillRoundingError = 'ORDER_FILL_ROUNDING_ERROR',
     FillBalanceAllowanceError = 'FILL_BALANCE_ALLOWANCE_ERROR',

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -11,10 +11,10 @@ export class OrderValidationUtils {
         this.tokenWrapper = tokenWrapper;
         this.exchangeWrapper = exchangeWrapper;
     }
-    public async validateFillOrderAndThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                         fillTakerTokenAmount: BigNumber.BigNumber,
-                                                         takerAddress: string,
-                                                         zrxTokenAddress: string): Promise<void> {
+    public async validateFillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
+                                                      fillTakerTokenAmount: BigNumber.BigNumber,
+                                                      takerAddress: string,
+                                                      zrxTokenAddress: string): Promise<void> {
         if (fillTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderRemainingFillAmountZero);
         }
@@ -36,11 +36,11 @@ export class OrderValidationUtils {
             throw new Error(ExchangeContractErrs.OrderFillRoundingError);
         }
     }
-    public async validateFillOrKillOrderAndThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                               fillTakerTokenAmount: BigNumber.BigNumber,
-                                                               takerAddress: string,
-                                                               zrxTokenAddress: string): Promise<void> {
-        await this.validateFillOrderAndThrowIfInvalidAsync(
+    public async validateFillOrKillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
+                                                            fillTakerTokenAmount: BigNumber.BigNumber,
+                                                            takerAddress: string,
+                                                            zrxTokenAddress: string): Promise<void> {
+        await this.validateFillOrderThrowIfInvalidAsync(
             signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
         // Check that fillValue available >= fillTakerAmount
         const orderHashHex = utils.getOrderHashHex(signedOrder);
@@ -50,9 +50,9 @@ export class OrderValidationUtils {
             throw new Error(ExchangeContractErrs.InsufficientRemainingFillAmount);
         }
     }
-    public async validateCancelOrderAndThrowIfInvalidAsync(order: Order,
-                                                           cancelTakerTokenAmount: BigNumber.BigNumber,
-                                                           unavailableTakerTokenAmount: BigNumber.BigNumber,
+    public async validateCancelOrderThrowIfInvalidAsync(order: Order,
+                                                        cancelTakerTokenAmount: BigNumber.BigNumber,
+                                                        unavailableTakerTokenAmount: BigNumber.BigNumber,
     ): Promise<void> {
         if (cancelTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderCancelAmountZero);

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -58,7 +58,6 @@ export class OrderValidationUtils {
         if (cancelTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderCancelAmountZero);
         }
-        const orderHash = utils.getOrderHashHex(order);
         if (order.takerTokenAmount.minus(unavailableTakerTokenAmount).eq(0)) {
             throw new Error(ExchangeContractErrs.OrderAlreadyCancelledOrFilled);
         }

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -16,6 +16,11 @@ export class OrderValidationUtils {
                                                       takerAddress: string,
                                                       zrxTokenAddress: string): Promise<void> {
         if (fillTakerTokenAmount.eq(0)) {
+            throw new Error(ExchangeContractErrs.OrderFillAmountZero);
+        }
+        const orderHash = utils.getOrderHashHex(signedOrder);
+        const unavailableTakerTokenAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHash);
+        if (signedOrder.makerTokenAmount.eq(unavailableTakerTokenAmount)) {
             throw new Error(ExchangeContractErrs.OrderRemainingFillAmountZero);
         }
         if (signedOrder.taker !== constants.NULL_ADDRESS && signedOrder.taker !== takerAddress) {

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -41,7 +41,8 @@ export class OrderValidationUtils {
                                                             takerAddress: string,
                                                             zrxTokenAddress: string): Promise<void> {
         await this.validateFillOrderThrowIfInvalidAsync(
-            signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
+            signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
+        );
         // Check that fillValue available >= fillTakerAmount
         const orderHashHex = utils.getOrderHashHex(signedOrder);
         const unavailableTakerAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHashHex);

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -58,7 +58,7 @@ export class OrderValidationUtils {
         if (cancelTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderCancelAmountZero);
         }
-        if (order.takerTokenAmount.minus(unavailableTakerTokenAmount).eq(0)) {
+        if (order.takerTokenAmount.eq(unavailableTakerTokenAmount)) {
             throw new Error(ExchangeContractErrs.OrderAlreadyCancelledOrFilled);
         }
         const currentUnixTimestampSec = utils.getCurrentUnixTimestamp();

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -1,10 +1,70 @@
-import {ExchangeContractErrs, SignedOrder} from '../types';
+import {ExchangeContractErrs, SignedOrder, Order} from '../types';
 import {TokenWrapper} from '../contract_wrappers/token_wrapper';
+import {ExchangeWrapper} from '../contract_wrappers/exchange_wrapper';
+import {utils} from '../utils/utils';
+import {constants} from '../utils/constants';
 
 export class OrderValidationUtils {
     private tokenWrapper: TokenWrapper;
-    constructor(tokenWrapper: TokenWrapper) {
+    private exchangeWrapper: ExchangeWrapper;
+    constructor(tokenWrapper: TokenWrapper, exchangeWrapper: ExchangeWrapper) {
         this.tokenWrapper = tokenWrapper;
+        this.exchangeWrapper = exchangeWrapper;
+    }
+    public async validateFillOrderAndThrowIfInvalidAsync(signedOrder: SignedOrder,
+                                                         fillTakerTokenAmount: BigNumber.BigNumber,
+                                                         takerAddress: string,
+                                                         zrxTokenAddress: string): Promise<void> {
+        if (fillTakerTokenAmount.eq(0)) {
+            throw new Error(ExchangeContractErrs.OrderRemainingFillAmountZero);
+        }
+        if (signedOrder.taker !== constants.NULL_ADDRESS && signedOrder.taker !== takerAddress) {
+            throw new Error(ExchangeContractErrs.TransactionSenderIsNotFillOrderTaker);
+        }
+        const currentUnixTimestampSec = utils.getCurrentUnixTimestamp();
+        if (signedOrder.expirationUnixTimestampSec.lessThan(currentUnixTimestampSec)) {
+            throw new Error(ExchangeContractErrs.OrderFillExpired);
+        }
+        await this.validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
+            signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
+        );
+
+        const wouldRoundingErrorOccur = await this.exchangeWrapper.isRoundingErrorAsync(
+            fillTakerTokenAmount, signedOrder.takerTokenAmount, signedOrder.makerTokenAmount,
+        );
+        if (wouldRoundingErrorOccur) {
+            throw new Error(ExchangeContractErrs.OrderFillRoundingError);
+        }
+    }
+    public async validateFillOrKillOrderAndThrowIfInvalidAsync(signedOrder: SignedOrder,
+                                                               fillTakerTokenAmount: BigNumber.BigNumber,
+                                                               takerAddress: string,
+                                                               zrxTokenAddress: string): Promise<void> {
+        await this.validateFillOrderAndThrowIfInvalidAsync(
+            signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
+        // Check that fillValue available >= fillTakerAmount
+        const orderHashHex = utils.getOrderHashHex(signedOrder);
+        const unavailableTakerAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHashHex);
+        const remainingTakerAmount = signedOrder.takerTokenAmount.minus(unavailableTakerAmount);
+        if (remainingTakerAmount < fillTakerTokenAmount) {
+            throw new Error(ExchangeContractErrs.InsufficientRemainingFillAmount);
+        }
+    }
+    public async validateCancelOrderAndThrowIfInvalidAsync(order: Order,
+                                                           cancelTakerTokenAmount: BigNumber.BigNumber,
+                                                           unavailableTakerTokenAmount: BigNumber.BigNumber,
+    ): Promise<void> {
+        if (cancelTakerTokenAmount.eq(0)) {
+            throw new Error(ExchangeContractErrs.OrderCancelAmountZero);
+        }
+        const orderHash = utils.getOrderHashHex(order);
+        if (order.takerTokenAmount.minus(unavailableTakerTokenAmount).eq(0)) {
+            throw new Error(ExchangeContractErrs.OrderAlreadyCancelledOrFilled);
+        }
+        const currentUnixTimestampSec = utils.getCurrentUnixTimestamp();
+        if (order.expirationUnixTimestampSec.lessThan(currentUnixTimestampSec)) {
+            throw new Error(ExchangeContractErrs.OrderCancelExpired);
+        }
     }
     public async validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
         signedOrder: SignedOrder, fillTakerAmount: BigNumber.BigNumber, senderAddress: string, zrxTokenAddress: string,

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -151,6 +151,7 @@ describe('OrderValidation', () => {
     describe('#validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync', () => {
         describe('should throw when not enough balance or allowance to fulfill the order', () => {
             const balanceToSubtractFromMaker = new BigNumber(3);
+            const balanceToSubtractFromTaker = new BigNumber(3);
             const lackingAllowance = new BigNumber(3);
             let signedOrder: SignedOrder;
             beforeEach('create fillable signed order', async () => {
@@ -160,10 +161,10 @@ describe('OrderValidation', () => {
             });
             it('should throw when taker balance is less than fill amount', async () => {
                 await zeroEx.token.transferAsync(
-                    takerTokenAddress, takerAddress, coinbase, balanceToSubtractFromMaker,
+                    takerTokenAddress, takerAddress, coinbase, balanceToSubtractFromTaker,
                 );
                 return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerBalance);
             });
             it('should throw when taker allowance is less than fill amount', async () => {
@@ -171,23 +172,23 @@ describe('OrderValidation', () => {
                 await zeroEx.token.setProxyAllowanceAsync(takerTokenAddress, takerAddress,
                     newAllowanceWhichIsLessThanFillAmount);
                 return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerAllowance);
             });
             it('should throw when maker balance is less than maker fill amount', async () => {
                 await zeroEx.token.transferAsync(
                     makerTokenAddress, makerAddress, coinbase, balanceToSubtractFromMaker,
                 );
-                return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                return expect((orderValidationUtils as any).validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerBalance);
             });
             it('should throw when maker allowance is less than maker fill amount', async () => {
                 const newAllowanceWhichIsLessThanFillAmount = fillTakerAmount.minus(lackingAllowance);
                 await zeroEx.token.setProxyAllowanceAsync(makerTokenAddress, makerAddress,
                     newAllowanceWhichIsLessThanFillAmount);
-                return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                return expect((orderValidationUtils as any).validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerAllowance);
             });
         });
@@ -206,16 +207,16 @@ describe('OrderValidation', () => {
                 await zeroEx.token.transferAsync(
                     zrxTokenAddress, makerAddress, coinbase, balanceToSubtractFromMaker,
                 );
-                return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                return expect((orderValidationUtils as any).validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
+                    signedOrder, fillTakerAmount, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerFeeBalance);
             });
             it('should throw when maker doesn\'t have enough allowance to pay fees', async () => {
                 const newAllowanceWhichIsLessThanFees = makerFee.minus(1);
                 await zeroEx.token.setProxyAllowanceAsync(zrxTokenAddress, makerAddress,
                     newAllowanceWhichIsLessThanFees);
-                return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                return expect((orderValidationUtils as any).validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
+                    signedOrder, fillTakerAmount, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerFeeAllowance);
             });
             it('should throw when taker doesn\'t have enough balance to pay fees', async () => {
@@ -224,7 +225,7 @@ describe('OrderValidation', () => {
                     zrxTokenAddress, takerAddress, coinbase, balanceToSubtractFromTaker,
                 );
                 return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerFeeBalance);
             });
             it('should throw when taker doesn\'t have enough allowance to pay fees', async () => {
@@ -232,7 +233,7 @@ describe('OrderValidation', () => {
                 await zeroEx.token.setProxyAllowanceAsync(zrxTokenAddress, takerAddress,
                     newAllowanceWhichIsLessThanFees);
                 return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerFeeAllowance);
             });
         });
@@ -252,8 +253,8 @@ describe('OrderValidation', () => {
                 await zeroEx.token.transferAsync(
                     zrxTokenAddress, makerAddress, coinbase, balanceToSubtractFromMaker,
                 );
-                return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                return expect((orderValidationUtils as any).validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
+                    signedOrder, fillTakerAmount, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerBalance);
             });
             it('should throw on insufficient allowance when makerToken is ZRX', async () => {
@@ -261,8 +262,8 @@ describe('OrderValidation', () => {
                 const newAllowanceWhichIsInsufficient = oldAllowance.minus(1);
                 await zeroEx.token.setProxyAllowanceAsync(
                     zrxTokenAddress, makerAddress, newAllowanceWhichIsInsufficient);
-                return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                return expect((orderValidationUtils as any).validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
+                    signedOrder, fillTakerAmount, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerAllowance);
             });
         });
@@ -283,7 +284,7 @@ describe('OrderValidation', () => {
                     zrxTokenAddress, takerAddress, coinbase, balanceToSubtractFromTaker,
                 );
                 return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerBalance);
             });
             it('should throw on insufficient allowance when takerToken is ZRX', async () => {
@@ -292,7 +293,7 @@ describe('OrderValidation', () => {
                 await zeroEx.token.setProxyAllowanceAsync(
                     zrxTokenAddress, takerAddress, newAllowanceWhichIsInsufficient);
                 return expect((orderValidationUtils as any).validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-                    signedOrder, fillTakerAmount, takerAddress,
+                    signedOrder, fillTakerAmount, takerAddress, zrxTokenAddress,
                 )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerAllowance);
             });
         });

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -62,6 +62,15 @@ describe('OrderValidation', () => {
             const zeroFillAmount = new BigNumber(0);
             return expect(zeroEx.exchange.validateFillOrderThrowIfInvalidAsync(
                 signedOrder, zeroFillAmount, takerAddress,
+            )).to.be.rejectedWith(ExchangeContractErrs.OrderFillAmountZero);
+        });
+        it('should throw when the order is fully filled or cancelled', async () => {
+            const signedOrder = await fillScenarios.createFillableSignedOrderAsync(
+                makerTokenAddress, takerTokenAddress, makerAddress, takerAddress, fillableAmount,
+            );
+            await zeroEx.exchange.cancelOrderAsync(signedOrder, fillableAmount);
+            return expect(zeroEx.exchange.validateFillOrderThrowIfInvalidAsync(
+                signedOrder, fillableAmount, takerAddress,
             )).to.be.rejectedWith(ExchangeContractErrs.OrderRemainingFillAmountZero);
         });
         it('should throw when sender is not a taker', async () => {


### PR DESCRIPTION
This PR:
* Adds 4 new public functions
    * `zeroEx.exchange.validateFillOrderAndThrowIfInvalidAsync`
    * `zeroEx.exchange.validateFillOrKillOrderAndThrowIfInvalidAsync` (calls the previous one under the hood)
    * `zeroEx.exchange.validateCancelOrderAndThrowIfInvalidAsync`
    * `zeroEx.exchange.isRoundingErrorAsync`