### PR TITLE
Add public method to TokenRegistry

### DIFF
--- a/src/contract_wrappers/token_registry_wrapper.ts
+++ b/src/contract_wrappers/token_registry_wrapper.ts
@@ -24,7 +24,7 @@ export class TokenRegistryWrapper extends ContractWrapper {
         const addresses = await tokenRegistryContract.getTokenAddresses.call();
         const tokenPromises: Array<Promise<Token|undefined>> = _.map(
             addresses,
-            (address: string) => (this.getTokenMetadataIfExistsAsync(address)),
+            (address: string) => (this.getTokenIfExistsAsync(address)),
         );
         const tokens = await Promise.all(tokenPromises);
         return tokens as Token[];
@@ -33,7 +33,7 @@ export class TokenRegistryWrapper extends ContractWrapper {
      * Retrieves a token by address currently listed in the Token Registry smart contract
      * @return  An object that conforms to the Token interface or undefined if token not found.
      */
-    public async getTokenMetadataIfExistsAsync(address: string): Promise<Token|undefined> {
+    public async getTokenIfExistsAsync(address: string): Promise<Token|undefined> {
         assert.isETHAddressHex('address', address);
 
         const tokenRegistryContract = await this._getTokenRegistryContractAsync();

--- a/src/contract_wrappers/token_registry_wrapper.ts
+++ b/src/contract_wrappers/token_registry_wrapper.ts
@@ -1,5 +1,6 @@
 import * as _ from 'lodash';
 import {Web3Wrapper} from '../web3_wrapper';
+import {assert} from '../utils/assert';
 import {Token, TokenRegistryContract, TokenMetadata} from '../types';
 import {constants} from '../utils/constants';
 import {ContractWrapper} from './contract_wrapper';
@@ -33,6 +34,8 @@ export class TokenRegistryWrapper extends ContractWrapper {
      * @return  An object that conforms to the Token interface or undefined if token not found.
      */
     public async getTokenMetadataIfExistsAsync(address: string): Promise<Token|undefined> {
+        assert.isETHAddressHex('address', address);
+
         const tokenRegistryContract = await this._getTokenRegistryContractAsync();
         const metadata = await tokenRegistryContract.getTokenMetaData.call(address);
         if (metadata[0] === constants.NULL_ADDRESS) {

--- a/test/token_registry_wrapper_test.ts
+++ b/test/token_registry_wrapper_test.ts
@@ -49,8 +49,8 @@ describe('TokenRegistryWrapper', () => {
             expect(validationResult.errors).to.have.lengthOf(0);
         });
         it('should return return undefined when passed a token address not in the tokenRegistry', async () => {
-            const unregisteredTokenAddress = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
             const tokenIfExists = await zeroEx.tokenRegistry.getTokenMetadataIfExistsAsync(unregisteredTokenAddress);
+            const unregisteredTokenAddress = '0x5409ed021d9299bf6814279a6a1411a7e866a631';
             expect(tokenIfExists).to.be.undefined();
         });
     });

--- a/test/token_registry_wrapper_test.ts
+++ b/test/token_registry_wrapper_test.ts
@@ -38,4 +38,20 @@ describe('TokenRegistryWrapper', () => {
             });
         });
     });
+    describe('#getTokenMetadataIfExistsAsync', () => {
+        it('should return the token added to the tokenRegistry during the migration', async () => {
+            const tokens = await zeroEx.tokenRegistry.getTokensAsync();
+            const aToken = tokens[0];
+
+            const token = await zeroEx.tokenRegistry.getTokenMetadataIfExistsAsync(aToken.address);
+            const schemaValidator = new SchemaValidator();
+            const validationResult = schemaValidator.validate(token, tokenSchema);
+            expect(validationResult.errors).to.have.lengthOf(0);
+        });
+        it('should return return undefined when passed a token address not in the tokenRegistry', async () => {
+            const unregisteredTokenAddress = '0x5409ED021D9299bf6814279A6A1411A7e866A631';
+            const tokenIfExists = await zeroEx.tokenRegistry.getTokenMetadataIfExistsAsync(unregisteredTokenAddress);
+            expect(tokenIfExists).to.be.undefined();
+        });
+    });
 });

--- a/test/token_registry_wrapper_test.ts
+++ b/test/token_registry_wrapper_test.ts
@@ -38,19 +38,19 @@ describe('TokenRegistryWrapper', () => {
             });
         });
     });
-    describe('#getTokenMetadataIfExistsAsync', () => {
+    describe('#getTokenIfExistsAsync', () => {
         it('should return the token added to the tokenRegistry during the migration', async () => {
             const tokens = await zeroEx.tokenRegistry.getTokensAsync();
             const aToken = tokens[0];
 
-            const token = await zeroEx.tokenRegistry.getTokenMetadataIfExistsAsync(aToken.address);
+            const token = await zeroEx.tokenRegistry.getTokenIfExistsAsync(aToken.address);
             const schemaValidator = new SchemaValidator();
             const validationResult = schemaValidator.validate(token, tokenSchema);
             expect(validationResult.errors).to.have.lengthOf(0);
         });
         it('should return return undefined when passed a token address not in the tokenRegistry', async () => {
-            const tokenIfExists = await zeroEx.tokenRegistry.getTokenMetadataIfExistsAsync(unregisteredTokenAddress);
             const unregisteredTokenAddress = '0x5409ed021d9299bf6814279a6a1411a7e866a631';
+            const tokenIfExists = await zeroEx.tokenRegistry.getTokenIfExistsAsync(unregisteredTokenAddress);
             expect(tokenIfExists).to.be.undefined();
         });
     });


### PR DESCRIPTION
This PR:
- Adds public method `getTokenMetadataIfExistsAsync` to TokenRegistry wrapper
- Refactors `getTokensAsync` to use `getTokenMetadataIfExistsAsync` under the hood
- Adds relevant unit tests