### PR TITLE
Specify tag and other values in the release script

### DIFF
--- a/package.json
+++ b/package.json
@@ -16,7 +16,7 @@
     "build": "run-p build:*:prod",
     "prepublishOnly": "run-p build:umd:prod build:commonjs:dev",
     "postpublish": "run-s release docs:json upload_docs_json",
-    "release": "publish-release --assets _bundles/index.js,_bundles/index.min.js",
+    "release": "publish-release --assets _bundles/index.js,_bundles/index.min.js --tag $(git describe --tags) --owner 0xProject --repo 0x.js",
     "upload_docs_json": "aws s3 cp docs/index.json s3://0xjs-docs-jsons/$(git describe --tags).json --profile 0xproject --grants read=uri=http://acs.amazonaws.com/groups/global/AllUsers --content-type aplication/json",
     "lint": "tslint src/*.ts test/*.ts",
     "test": "run-s clean test:commonjs",


### PR DESCRIPTION
This PR:
* Is a reply to today's publishing issue with 0.10.0

What happened?
<img width="523" alt="screen shot 2017-08-24 at 11 15 50" src="https://user-images.githubusercontent.com/6204356/29659169-a0bae7e2-88bd-11e7-8d23-16196bd49c29.png">

`publish-release`asked me to select a tag from the list, but the newest tag was not there and I was not able to move with the arrows.
I think - it's because v0.10.0 is lexicographically less than for example 0.6.0.

This PR:
* Specifies the correct tag the same way we do it for the docs in the params of `publish-release`, so a developer doesn't need to select it. It also specifies an owner and the repo name. Two clicks less.
