### PR TITLE
Add 'content-type' header with value 'application/json' for http requ… 

### DIFF
--- a/test/utils/rpc.ts
+++ b/test/utils/rpc.ts
@@ -40,6 +40,9 @@ export class RPC {
             method: 'POST',
             uri: `http://${this.host}:${this.port}`,
             body: payload,
+            headers: {
+                'content-type': 'application/json'
+            },
         };
         const bodyString = await request(opts);
         const body = JSON.parse(bodyString);


### PR DESCRIPTION
…ests made JSONRPC endpoints

This PR:
* the parity ethereum client rejects http requests that do not include a json content-type https://github.com/paritytech/parity/wiki/FAQ%3A-CLI%2C-Mining%2C-and-Networks#none-of-my-jsonrpc-requests-work-they-all-fail-with-no-output
* other clients may adopt a similar error in the future
