### PR TITLE
Feature/throw for exchange errors

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+v0.13.1 - _September 6, 2017_
+------------------------
+    * Fixed an issue with overlapping async intervals in `zeroEx.awaitTransactionMinedAsync` (#157)
+    * Fixed an issue with log decoder returning `BigNumber`s as `strings` (#157)
+
 v0.13.0 - _September 6, 2017_
 ------------------------
     * Made all the functions submitting transactions to the network to immediately return transaction hash (#151)

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 v0.13.1 - _September 6, 2017_
 ------------------------
+    * Added `zeroEx.exchange.throwLogErrorsAsErrors` method to public interface (#157)
     * Fixed an issue with overlapping async intervals in `zeroEx.awaitTransactionMinedAsync` (#157)
     * Fixed an issue with log decoder returning `BigNumber`s as `strings` (#157)
 

--- a/src/0x.ts
+++ b/src/0x.ts
@@ -13,7 +13,7 @@ import {utils} from './utils/utils';
 import {signatureUtils} from './utils/signature_utils';
 import {assert} from './utils/assert';
 import {AbiDecoder} from './utils/abi_decoder';
-import {IntervalUtils} from './utils/interval_utils';
+import {intervalUtils} from './utils/interval_utils';
 import {artifacts} from './artifacts';
 import {ExchangeWrapper} from './contract_wrappers/exchange_wrapper';
 import {TokenRegistryWrapper} from './contract_wrappers/token_registry_wrapper';
@@ -73,7 +73,6 @@ export class ZeroEx {
     public proxy: TokenTransferProxyWrapper;
     private _web3Wrapper: Web3Wrapper;
     private _abiDecoder: AbiDecoder;
-    private _intervalUtils: IntervalUtils;
     /**
      * Verifies that the elliptic curve signature `signature` was generated
      * by signing `data` with the private key corresponding to the `signerAddress` address.
@@ -194,7 +193,6 @@ export class ZeroEx {
         const defaults = {
             gasPrice,
         };
-        this._intervalUtils = new IntervalUtils();
         this._web3Wrapper = new Web3Wrapper(provider, defaults);
         this.token = new TokenWrapper(this._web3Wrapper);
         this.proxy = new TokenTransferProxyWrapper(this._web3Wrapper);
@@ -283,10 +281,10 @@ export class ZeroEx {
         txHash: string, pollingIntervalMs: number = 1000): Promise<TransactionReceiptWithDecodedLogs> {
         const txReceiptPromise = new Promise(
             (resolve: (receipt: TransactionReceiptWithDecodedLogs) => void, reject) => {
-            const intervalId = this._intervalUtils.setAsyncExcludingInterval(async () => {
+            const intervalId = intervalUtils.setAsyncExcludingInterval(async () => {
                 const transactionReceipt = await this._web3Wrapper.getTransactionReceiptAsync(txHash);
                 if (!_.isNull(transactionReceipt)) {
-                    this._intervalUtils.clearAsyncExcludingInterval(intervalId);
+                    intervalUtils.clearAsyncExcludingInterval(intervalId);
                     const logsWithDecodedArgs = _.map(transactionReceipt.logs, (log: Web3.LogEntry) => {
                         const decodedLog = this._abiDecoder.decodeLog(log);
                         if (_.isUndefined(decodedLog)) {

--- a/src/0x.ts
+++ b/src/0x.ts
@@ -13,6 +13,7 @@ import {utils} from './utils/utils';
 import {signatureUtils} from './utils/signature_utils';
 import {assert} from './utils/assert';
 import {AbiDecoder} from './utils/abi_decoder';
+import {IntervalUtils} from './utils/interval_utils';
 import {artifacts} from './artifacts';
 import {ExchangeWrapper} from './contract_wrappers/exchange_wrapper';
 import {TokenRegistryWrapper} from './contract_wrappers/token_registry_wrapper';
@@ -72,6 +73,7 @@ export class ZeroEx {
     public proxy: TokenTransferProxyWrapper;
     private _web3Wrapper: Web3Wrapper;
     private _abiDecoder: AbiDecoder;
+    private _intervalUtils: IntervalUtils;
     /**
      * Verifies that the elliptic curve signature `signature` was generated
      * by signing `data` with the private key corresponding to the `signerAddress` address.
@@ -192,6 +194,7 @@ export class ZeroEx {
         const defaults = {
             gasPrice,
         };
+        this._intervalUtils = new IntervalUtils();
         this._web3Wrapper = new Web3Wrapper(provider, defaults);
         this.token = new TokenWrapper(this._web3Wrapper);
         this.proxy = new TokenTransferProxyWrapper(this._web3Wrapper);
@@ -280,10 +283,10 @@ export class ZeroEx {
         txHash: string, pollingIntervalMs: number = 1000): Promise<TransactionReceiptWithDecodedLogs> {
         const txReceiptPromise = new Promise(
             (resolve: (receipt: TransactionReceiptWithDecodedLogs) => void, reject) => {
-            const intervalId = setInterval(async () => {
+            const intervalId = this._intervalUtils.setAsyncExcludingInterval(async () => {
                 const transactionReceipt = await this._web3Wrapper.getTransactionReceiptAsync(txHash);
                 if (!_.isNull(transactionReceipt)) {
-                    clearInterval(intervalId);
+                    this._intervalUtils.clearAsyncExcludingInterval(intervalId);
                     const logsWithDecodedArgs = _.map(transactionReceipt.logs, (log: Web3.LogEntry) => {
                         const decodedLog = this._abiDecoder.decodeLog(log);
                         if (_.isUndefined(decodedLog)) {

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -685,10 +685,10 @@ export class ExchangeWrapper extends ContractWrapper {
     }
     /**
      * Checks if logs contain LogError, which is emmited by Exchange contract on transaction failure.
-     * @param   logsWithdecodedArgs   Transaction logs as returned by `zeroEx.awaitTransactionMinedAsync`
+     * @param   logsWithDecodedArgs   Transaction logs as returned by `zeroEx.awaitTransactionMinedAsync`
      */
-    public throwLogErrorsAsErrors(logsWithdecodedArgs: LogWithDecodedArgs[]): void {
-        const errLog = _.find(logsWithdecodedArgs, {event: 'LogError'});
+    public throwLogErrorsAsErrors(logsWithDecodedArgs: LogWithDecodedArgs[]): void {
+        const errLog = _.find(logsWithDecodedArgs, {event: ExchangeEvents.LogError});
         if (!_.isUndefined(errLog)) {
             const logArgs: LogErrorContractEventArgs = errLog.args as any;
             const errCode = logArgs.errorId.toNumber();

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -684,8 +684,7 @@ export class ExchangeWrapper extends ContractWrapper {
         return isRoundingError;
     }
     /**
-     * Checks if logs contain LogError, which is emited by Exchange contract on transfer failure
-     * and throws an appropriate error.
+     * Checks if logs contain LogError, which is emmited by Exchange contract on transaction failure.
      * @param   logsWithdecodedArgs   Transaction logs as returned by `zeroEx.awaitTransactionMinedAsync`
      */
     public throwLogErrorsAsErrors(logsWithdecodedArgs: LogWithDecodedArgs[]): void {

--- a/src/utils/abi_decoder.ts
+++ b/src/utils/abi_decoder.ts
@@ -1,5 +1,6 @@
 import * as Web3 from 'web3';
 import * as _ from 'lodash';
+import * as BigNumber from 'bignumber.js';
 import {AbiType, DecodedLogArgs, DecodedArgs} from '../types';
 import * as SolidityCoder from 'web3/lib/solidity/coder';
 
@@ -31,9 +32,9 @@ export class AbiDecoder {
                     dataIndex++;
                 }
                 if (param.type === 'address') {
-                    value = this.padZeros(new Web3().toBigNumber(value).toString(16));
+                    value = this.padZeros(new BigNumber(value).toString(16));
                 } else if (param.type === 'uint256' || param.type === 'uint8' || param.type === 'int' ) {
-                    value = new Web3().toBigNumber(value).toString(10);
+                    value = new BigNumber(value);
                 }
                 decodedParams[param.name] = value;
             });

--- a/src/utils/interval_utils.ts
+++ b/src/utils/interval_utils.ts
@@ -4,7 +4,7 @@ export class IntervalUtils {
     private mutex: {[intervalId: number]: boolean} = {};
     public setAsyncExcludingInterval(fn: () => Promise<void>, intervalMs: number) {
         const intervalId = setInterval(async () => {
-            if (_.isUndefined(this.mutex[intervalId])) {
+            if (!_.isUndefined(this.mutex[intervalId])) {
                 return;
             } else {
                 this.mutex[intervalId] = true;

--- a/src/utils/interval_utils.ts
+++ b/src/utils/interval_utils.ts
@@ -1,0 +1,20 @@
+import * as _ from 'lodash';
+
+export class IntervalUtils {
+    private mutex: {[intervalId: number]: boolean} = {};
+    public setAsyncExcludingInterval(fn: () => Promise<void>, intervalMs: number) {
+        const intervalId = setInterval(async () => {
+            if (_.isUndefined(this.mutex[intervalId])) {
+                return;
+            } else {
+                this.mutex[intervalId] = true;
+                await fn();
+                delete this.mutex[intervalId];
+            }
+        });
+        return intervalId;
+    }
+    public clearAsyncExcludingInterval(intervalId: number): void {
+        clearInterval(intervalId);
+    }
+}

--- a/src/utils/interval_utils.ts
+++ b/src/utils/interval_utils.ts
@@ -1,20 +1,20 @@
 import * as _ from 'lodash';
 
-export class IntervalUtils {
-    private mutex: {[intervalId: number]: boolean} = {};
-    public setAsyncExcludingInterval(fn: () => Promise<void>, intervalMs: number) {
+export const intervalUtils = {
+    setAsyncExcludingInterval(fn: () => Promise<void>, intervalMs: number) {
+        let locked = false;
         const intervalId = setInterval(async () => {
-            if (!_.isUndefined(this.mutex[intervalId])) {
+            if (locked) {
                 return;
             } else {
-                this.mutex[intervalId] = true;
+                locked = true;
                 await fn();
-                delete this.mutex[intervalId];
+                locked = false;
             }
         });
         return intervalId;
-    }
-    public clearAsyncExcludingInterval(intervalId: number): void {
+    },
+    clearAsyncExcludingInterval(intervalId: number): void {
         clearInterval(intervalId);
-    }
-}
+    },
+};

--- a/test/0x.js_test.ts
+++ b/test/0x.js_test.ts
@@ -226,11 +226,9 @@ describe('ZeroEx library', () => {
             const txReceiptWithDecodedLogs = await zeroEx.awaitTransactionMinedAsync(txHash);
             const log = txReceiptWithDecodedLogs.logs[0] as LogWithDecodedArgs;
             expect(log.event).to.be.equal('Approval');
-            expect(log.args).to.be.deep.equal({
-                _owner: coinbase,
-                _spender: proxyAddress,
-                _value: zeroEx.token.UNLIMITED_ALLOWANCE_IN_BASE_UNITS.toString(),
-            });
+            expect(log.args._owner).to.be.equal(coinbase);
+            expect(log.args._spender).to.be.equal(proxyAddress);
+            expect(log.args._value).to.be.bignumber.equal(zeroEx.token.UNLIMITED_ALLOWANCE_IN_BASE_UNITS);
         });
     });
 });


### PR DESCRIPTION
This PR:
* Adds `zeroEx.exchange.throwLogErrorsAsErrors`
* Fixes the issue, when log decoder returned `BigNumber`s as strings
