### PR TITLE
Add validateOrderFillableOrThrowAsync Method

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,7 @@
 # CHANGELOG
 
 v0.17.0 - _September 26, 2017_
+    * Added `zeroEx.exchange.validateOrderFillableOrThrowAsync` to simplify orderbook pruning (#170)
     * Made `zeroEx.exchange.getZRXTokenAddressAsync` public (#171)
 
 v0.16.0 - _September 20, 2017_

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -633,7 +633,7 @@ export class ExchangeWrapper extends ContractWrapper {
      *                          to validate for.
      */
     public async validateOrderFillableOrThrowAsync(
-        signedOrder: SignedOrder, opts: ValidateOrderFillableOpts,
+        signedOrder: SignedOrder, opts?: ValidateOrderFillableOpts,
     ): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
         const zrxTokenAddress = await this._getZRXTokenAddressAsync();

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -637,7 +637,7 @@ export class ExchangeWrapper extends ContractWrapper {
         signedOrder: SignedOrder, opts?: ValidateOrderFillableOpts,
     ): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
-        const zrxTokenAddress = await this._getZRXTokenAddressAsync();
+        const zrxTokenAddress = await this.getZRXTokenAddressAsync();
         const expectedFillTakerTokenAmount = !_.isUndefined(opts) ? opts.expectedFillTakerTokenAmount : undefined;
         await this._orderValidationUtils.validateOrderFillableOrThrowAsync(
             signedOrder, zrxTokenAddress, expectedFillTakerTokenAmount,

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -28,6 +28,7 @@ import {
     LogCancelContractEventArgs,
     LogWithDecodedArgs,
     MethodOpts,
+    ValidateOrderFillableOpts,
 } from '../types';
 import {assert} from '../utils/assert';
 import {utils} from '../utils/utils';
@@ -622,6 +623,24 @@ export class ExchangeWrapper extends ContractWrapper {
         const exchangeInstance = await this._getExchangeContractAsync();
         const exchangeAddress = exchangeInstance.address;
         return exchangeAddress;
+    }
+    /**
+     * Checks if order is still fillable and throws an error otherwise.
+     * @param   signedOrder     An object that conforms to the SignedOrder interface. The
+     *                          signedOrder you wish to validate.
+     * @param   opts            An object that conforms to the ValidateOrderFillableOpts
+     *                          interface. Allows specifying a specific fillTakerTokenAmount
+     *                          to validate for.
+     */
+    public async validateOrderFillableThrowIfNotFillableAsync(
+        signedOrder: SignedOrder, opts: ValidateOrderFillableOpts,
+    ): Promise<void> {
+        assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
+        const zrxTokenAddress = await this._getZRXTokenAddressAsync();
+        const expectedFillTakerTokenAmount = !_.isUndefined(opts) ? opts.expectedFillTakerTokenAmount : undefined;
+        await this._orderValidationUtils.validateOrderFillableThrowIfNotFillableAsync(
+            signedOrder, zrxTokenAddress, expectedFillTakerTokenAmount,
+        );
     }
     /**
      * Checks if order fill will succeed and throws an error otherwise.

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -632,13 +632,13 @@ export class ExchangeWrapper extends ContractWrapper {
      *                          interface. Allows specifying a specific fillTakerTokenAmount
      *                          to validate for.
      */
-    public async validateOrderFillableThrowIfNotFillableAsync(
+    public async validateOrderFillableOrThrowAsync(
         signedOrder: SignedOrder, opts: ValidateOrderFillableOpts,
     ): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
         const zrxTokenAddress = await this._getZRXTokenAddressAsync();
         const expectedFillTakerTokenAmount = !_.isUndefined(opts) ? opts.expectedFillTakerTokenAmount : undefined;
-        await this._orderValidationUtils.validateOrderFillableThrowIfNotFillableAsync(
+        await this._orderValidationUtils.validateOrderFillableOrThrowAsync(
             signedOrder, zrxTokenAddress, expectedFillTakerTokenAmount,
         );
     }

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -625,7 +625,8 @@ export class ExchangeWrapper extends ContractWrapper {
         return exchangeAddress;
     }
     /**
-     * Checks if order is still fillable and throws an error otherwise.
+     * Checks if order is still fillable and throws an error otherwise. Useful for orderbook
+     * pruning where you want to remove stale orders without knowing who the taker will be.
      * @param   signedOrder     An object that conforms to the SignedOrder interface. The
      *                          signedOrder you wish to validate.
      * @param   opts            An object that conforms to the ValidateOrderFillableOpts

--- a/src/types.ts
+++ b/src/types.ts
@@ -435,9 +435,9 @@ export interface Artifact {
 
 /*
  * expectedFillTakerTokenAmount: If specified, the validation method will ensure that the
- * supplied order's maker has a sufficient allowance/balance to fill this amount of the order's
+ * supplied order maker has a sufficient allowance/balance to fill this amount of the order's
  * takerTokenAmount. If not specified, the validation method ensures that the maker has a sufficient
- * allowance/balance to fill the entire remaining order.
+ * allowance/balance to fill the entire remaining order amount.
  */
 export interface ValidateOrderFillableOpts {
     expectedFillTakerTokenAmount?: BigNumber.BigNumber;

--- a/src/types.ts
+++ b/src/types.ts
@@ -434,6 +434,16 @@ export interface Artifact {
 }
 
 /*
+ * expectedFillTakerTokenAmount: If specified, the validation method will ensure that the
+ * supplied order's maker has a sufficient allowance/balance to fill this amount of the order's
+ * takerTokenAmount. If not specified, the validation method ensures that the maker has a sufficient
+ * allowance/balance to fill the entire remaining order.
+ */
+export interface ValidateOrderFillableOpts {
+    expectedFillTakerTokenAmount?: BigNumber.BigNumber;
+}
+
+/*
  * defaultBlock: The block up to which to query the blockchain state. Setting this to a historical block number
  * let's the user query the blockchain's state at an arbitrary point in time. In order for this to work, the
  * backing  Ethereum node must keep the entire historical state of the chain (e.g setting `--pruning=archive`

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -13,7 +13,7 @@ export class OrderValidationUtils {
         this.tokenWrapper = tokenWrapper;
         this.exchangeWrapper = exchangeWrapper;
     }
-    public async validateOrderFillableThrowIfNotFillableAsync(
+    public async validateOrderFillableOrThrowAsync(
         signedOrder: SignedOrder, zrxTokenAddress: string, expectedFillTakerTokenAmount?: BigNumber.BigNumber,
     ): Promise<void> {
         const orderHash = utils.getOrderHashHex(signedOrder);

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -18,7 +18,7 @@ export class OrderValidationUtils {
     ): Promise<void> {
         const orderHash = utils.getOrderHashHex(signedOrder);
         const unavailableTakerTokenAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHash);
-        if (signedOrder.makerTokenAmount.eq(unavailableTakerTokenAmount)) {
+        if (signedOrder.takerTokenAmount.eq(unavailableTakerTokenAmount)) {
             throw new Error(ExchangeContractErrs.OrderRemainingFillAmountZero);
         }
         const currentUnixTimestampSec = utils.getCurrentUnixTimestamp();
@@ -45,7 +45,7 @@ export class OrderValidationUtils {
             throw new Error(ZeroExError.InvalidSignature);
         }
         const unavailableTakerTokenAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHash);
-        if (signedOrder.makerTokenAmount.eq(unavailableTakerTokenAmount)) {
+        if (signedOrder.takerTokenAmount.eq(unavailableTakerTokenAmount)) {
             throw new Error(ExchangeContractErrs.OrderRemainingFillAmountZero);
         }
         if (signedOrder.taker !== constants.NULL_ADDRESS && signedOrder.taker !== takerAddress) {

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -55,6 +55,25 @@ describe('OrderValidation', () => {
         await blockchainLifecycle.revertAsync();
     });
     describe('validateOrderFillableOrThrowAsync', () => {
+        it('should succeed if the order is fillable', async () => {
+            const signedOrder = await fillScenarios.createFillableSignedOrderAsync(
+                makerTokenAddress, takerTokenAddress, makerAddress, takerAddress, fillableAmount,
+            );
+            await zeroEx.exchange.validateOrderFillableOrThrowAsync(
+                signedOrder,
+            );
+        });
+        it('should succeed if the order is asymmetric and fillable', async () => {
+            const makerFillableAmount = fillableAmount;
+            const takerFillableAmount = fillableAmount.minus(5000);
+            const signedOrder = await fillScenarios.createAsymmetricFillableSignedOrderAsync(
+                makerTokenAddress, takerTokenAddress, makerAddress, takerAddress,
+                makerFillableAmount, takerFillableAmount,
+            );
+            await zeroEx.exchange.validateOrderFillableOrThrowAsync(
+                signedOrder,
+            );
+        });
         it('should throw when the order is fully filled or cancelled', async () => {
             const signedOrder = await fillScenarios.createFillableSignedOrderAsync(
                 makerTokenAddress, takerTokenAddress, makerAddress, takerAddress, fillableAmount,

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -65,7 +65,7 @@ describe('OrderValidation', () => {
         });
         it('should succeed if the order is asymmetric and fillable', async () => {
             const makerFillableAmount = fillableAmount;
-            const takerFillableAmount = fillableAmount.minus(2);
+            const takerFillableAmount = fillableAmount.minus(4);
             const signedOrder = await fillScenarios.createAsymmetricFillableSignedOrderAsync(
                 makerTokenAddress, takerTokenAddress, makerAddress, takerAddress,
                 makerFillableAmount, takerFillableAmount,

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -54,6 +54,27 @@ describe('OrderValidation', () => {
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();
     });
+    describe('validateOrderFillableOrThrowAsync', () => {
+        it('should throw when the order is fully filled or cancelled', async () => {
+            const signedOrder = await fillScenarios.createFillableSignedOrderAsync(
+                makerTokenAddress, takerTokenAddress, makerAddress, takerAddress, fillableAmount,
+            );
+            await zeroEx.exchange.cancelOrderAsync(signedOrder, fillableAmount);
+            return expect(zeroEx.exchange.validateOrderFillableOrThrowAsync(
+                signedOrder,
+            )).to.be.rejectedWith(ExchangeContractErrs.OrderRemainingFillAmountZero);
+        });
+        it('should throw when order is expired', async () => {
+            const expirationInPast = new BigNumber(1496826058); // 7th Jun 2017
+            const signedOrder = await fillScenarios.createFillableSignedOrderAsync(
+                makerTokenAddress, takerTokenAddress, makerAddress, takerAddress,
+                fillableAmount, expirationInPast,
+            );
+            return expect(zeroEx.exchange.validateOrderFillableOrThrowAsync(
+                signedOrder,
+            )).to.be.rejectedWith(ExchangeContractErrs.OrderFillExpired);
+        });
+    });
     describe('validateFillOrderAndThrowIfInvalidAsync', () => {
         it('should throw when the fill amount is zero', async () => {
             const signedOrder = await fillScenarios.createFillableSignedOrderAsync(

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -65,7 +65,7 @@ describe('OrderValidation', () => {
         });
         it('should succeed if the order is asymmetric and fillable', async () => {
             const makerFillableAmount = fillableAmount;
-            const takerFillableAmount = fillableAmount.minus(5000);
+            const takerFillableAmount = fillableAmount.minus(2);
             const signedOrder = await fillScenarios.createAsymmetricFillableSignedOrderAsync(
                 makerTokenAddress, takerTokenAddress, makerAddress, takerAddress,
                 makerFillableAmount, takerFillableAmount,

--- a/test/utils/fill_scenarios.ts
+++ b/test/utils/fill_scenarios.ts
@@ -62,7 +62,9 @@ export class FillScenarios {
             fillableAmount, fillableAmount,
         );
         const shouldThrowOnInsufficientBalanceOrAllowance = false;
-        await this.zeroEx.exchange.fillOrderAsync(signedOrder, partialFillAmount, shouldThrowOnInsufficientBalanceOrAllowance, takerAddress);
+        await this.zeroEx.exchange.fillOrderAsync(
+            signedOrder, partialFillAmount, shouldThrowOnInsufficientBalanceOrAllowance, takerAddress,
+        );
         return signedOrder;
     }
     private async createAsymmetricFillableSignedOrderWithFeesAsync(


### PR DESCRIPTION
**Problem**: Relayers want a validation method with which to prune their orderbook. During pruning, they do not know who the order's eventual taker is going to be.

This PR:
* Adds a validation method that validates whether an order is fillable, without knowing the eventual taker. It validates that the order has not already been completely filled/cancelled, hasn't expired and that the maker still has a sufficient balance/allowance.
* The caller can optionally pass in a `opts.expectedFillTakerTokenAmount` to the validation. If omitted, the method ensures that the total remaining `takerTokenAmount` is fillable. If supplied, it validates that the order is fillable up to the passed `expectedFillTakerTokenAmount`. If a relayer wants to keep orders on their books that are partially unfillable, they could first query the makers balance/allowance and then call this method with `expectedFillTakerTokenAmount` set to the remaining maker balance that is also covered by a sufficient allowance to 0x.