### PR TITLE
Fix batch validation

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,6 +13,7 @@ v0.21.0 - _TBD, 2017_
         * Added `zeroEx.token.unsubscribe` and `zeroEx.exchange.unsubscribe`
         * Renamed `zeroEx.exchange.stopWatchingAllEventsAsync` to `zeroEx.exhange.unsubscribeAll`
         * Renamed `zeroEx.token.stopWatchingAllEventsAsync` to `zeroEx.token.unsubscribeAll`
+    * Fixed the batch fills validation by emulating all the transfers (#185)
 
 v0.20.0 - _October 5, 2017_
 ------------------------

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -13,7 +13,7 @@ v0.21.0 - _TBD, 2017_
         * Added `zeroEx.token.unsubscribe` and `zeroEx.exchange.unsubscribe`
         * Renamed `zeroEx.exchange.stopWatchingAllEventsAsync` to `zeroEx.exhange.unsubscribeAll`
         * Renamed `zeroEx.token.stopWatchingAllEventsAsync` to `zeroEx.token.unsubscribeAll`
-    * Fixed the batch fills validation by emulating all the transfers (#185)
+    * Fixed the batch fills validation by emulating all balance & proxy allowance changes (#185)
 
 v0.20.0 - _October 5, 2017_
 ------------------------

--- a/src/types.ts
+++ b/src/types.ts
@@ -466,3 +466,13 @@ export interface OrderTransactionOpts {
 }
 
 export type FilterObject = Web3.FilterObject;
+
+export enum TradeSide {
+    Maker = 'maker',
+    Taker = 'taker',
+}
+
+export enum TransferType {
+    Trade = 'trade',
+    Fee = 'fee',
+}

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -28,7 +28,7 @@ export const assert = {
         const web3 = new Web3();
         this.assert(web3.isAddress(value), this.typeAssertionMessage(variableName, 'ETHAddressHex', value));
         this.assert(
-            web3.isAddress(value) && !web3.isChecksumAddress(value),
+            web3.isAddress(value) && value.toLowerCase() === value,
             `Checksummed addresses are not supported. Convert ${variableName} to lower case before passing`,
         );
     },

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -1,0 +1,136 @@
+import * as _ from 'lodash';
+import {ExchangeContractErrs, TradeSide, TransferType} from '../types';
+import {TokenWrapper} from '../contract_wrappers/token_wrapper';
+
+enum FailureReason {
+    Balance = 'balance',
+    ProxyAllowance = 'proxy allowance',
+}
+
+const ERR_MSG_MAPPING = {
+    [FailureReason.Balance]: {
+        [TradeSide.Maker]: {
+            [TransferType.Trade]: ExchangeContractErrs.InsufficientMakerBalance,
+            [TransferType.Fee]: ExchangeContractErrs.InsufficientMakerFeeBalance,
+        },
+        [TradeSide.Taker]: {
+            [TransferType.Trade]: ExchangeContractErrs.InsufficientTakerBalance,
+            [TransferType.Fee]: ExchangeContractErrs.InsufficientTakerFeeBalance,
+        },
+    },
+    [FailureReason.ProxyAllowance]: {
+        [TradeSide.Maker]: {
+            [TransferType.Trade]: ExchangeContractErrs.InsufficientMakerAllowance,
+            [TransferType.Fee]: ExchangeContractErrs.InsufficientMakerFeeAllowance,
+        },
+        [TradeSide.Taker]: {
+            [TransferType.Trade]: ExchangeContractErrs.InsufficientTakerAllowance,
+            [TransferType.Fee]: ExchangeContractErrs.InsufficientTakerFeeAllowance,
+        },
+    },
+};
+
+/**
+ * Copy on read store for balances/proxyAllowances of tokens/accounts touched in trades
+ * @param  {TokenWrapper} token [description]
+ * @return {[type]}             [description]
+ */
+export class BalanceAndProxyAllowanceLazyStore {
+    protected _token: TokenWrapper;
+    private _balance: {
+        [tokenAddress: string]: {
+            [userAddress: string]: BigNumber.BigNumber,
+        },
+    };
+    private _proxyAllowance: {
+        [tokenAddress: string]: {
+            [userAddress: string]: BigNumber.BigNumber,
+        },
+    };
+    constructor(token: TokenWrapper) {
+        this._token = token;
+        this._balance = {};
+        this._proxyAllowance = {};
+    }
+    protected async getBalanceAsync(tokenAddress: string, userAddress: string): Promise<BigNumber.BigNumber> {
+        if (_.isUndefined(this._balance[tokenAddress]) || _.isUndefined(this._balance[tokenAddress][userAddress])) {
+            const balance = await this._token.getBalanceAsync(tokenAddress, userAddress);
+            this.setBalance(tokenAddress, userAddress, balance);
+        }
+        return this._balance[tokenAddress][userAddress];
+    }
+    protected setBalance(tokenAddress: string, userAddress: string, balance: BigNumber.BigNumber): void {
+        if (_.isUndefined(this._balance[tokenAddress])) {
+            this._balance[tokenAddress] = {};
+        }
+        this._balance[tokenAddress][userAddress] = balance;
+    }
+    protected async getProxyAllowanceAsync(tokenAddress: string, userAddress: string): Promise<BigNumber.BigNumber> {
+        if (_.isUndefined(this._proxyAllowance[tokenAddress]) ||
+            _.isUndefined(this._proxyAllowance[tokenAddress][userAddress])) {
+            const proxyAllowance = await this._token.getProxyAllowanceAsync(tokenAddress, userAddress);
+            this.setProxyAllowance(tokenAddress, userAddress, proxyAllowance);
+        }
+        return this._proxyAllowance[tokenAddress][userAddress];
+    }
+    protected setProxyAllowance(tokenAddress: string, userAddress: string, proxyAllowance: BigNumber.BigNumber): void {
+        if (_.isUndefined(this._proxyAllowance[tokenAddress])) {
+            this._proxyAllowance[tokenAddress] = {};
+        }
+        this._proxyAllowance[tokenAddress][userAddress] = proxyAllowance;
+    }
+}
+
+export class ExchangeTransferSimulator extends BalanceAndProxyAllowanceLazyStore {
+    constructor(token: TokenWrapper) {
+        super(token);
+    }
+    /**
+     * Simulates transferFrom call performed by a proxy
+     * @param  tokenAddress      Address of a token to be transfered
+     * @param  from              Owner of the transfered tokens
+     * @param  to                Recipient of the transfered tokens
+     * @param  amountInBaseUnits The amount of tokens being transfered
+     * @param  tradeSide         Is Maker/Taker transferring
+     * @param  transferType      Is it a fee payment or a value transfer
+     */
+    public async transferFromAsync(tokenAddress: string, from: string, to: string,
+                                   amountInBaseUnits: BigNumber.BigNumber, tradeSide: TradeSide,
+                                   transferType: TransferType): Promise<void> {
+        const balance = await this.getBalanceAsync(tokenAddress, from);
+        const proxyAllowance = await this.getProxyAllowanceAsync(tokenAddress, from);
+        if (balance.lessThan(amountInBaseUnits)) {
+            this.throwValidationError(FailureReason.Balance, tradeSide, transferType);
+        }
+        if (proxyAllowance.lessThan(amountInBaseUnits)) {
+            this.throwValidationError(FailureReason.ProxyAllowance, tradeSide, transferType);
+        }
+        await this.decreaseProxyAllowanceAsync(tokenAddress, from, amountInBaseUnits);
+        await this.decreaseBalanceAsync(tokenAddress, from, amountInBaseUnits);
+        if (!_.isUndefined(to)) {
+            await this.increaseBalanceAsync(tokenAddress, to, amountInBaseUnits);
+        }
+    }
+    private async decreaseProxyAllowanceAsync(tokenAddress: string, userAddress: string,
+                                              amountInBaseUnits: BigNumber.BigNumber): Promise<void> {
+        const proxyAllowance = await this.getProxyAllowanceAsync(tokenAddress, userAddress);
+        if (!proxyAllowance.eq(this._token.UNLIMITED_ALLOWANCE_IN_BASE_UNITS)) {
+            this.setProxyAllowance(tokenAddress, userAddress, proxyAllowance.minus(amountInBaseUnits));
+        }
+    }
+    private async increaseBalanceAsync(tokenAddress: string, userAddress: string,
+                                       amountInBaseUnits: BigNumber.BigNumber): Promise<void> {
+        const balance = await this.getBalanceAsync(tokenAddress, userAddress);
+        this.setBalance(tokenAddress, userAddress, balance.plus(amountInBaseUnits));
+    }
+    private async decreaseBalanceAsync(tokenAddress: string, userAddress: string,
+                                       amountInBaseUnits: BigNumber.BigNumber): Promise<void> {
+        const balance = await this.getBalanceAsync(tokenAddress, userAddress);
+        this.setBalance(tokenAddress, userAddress, balance.minus(amountInBaseUnits));
+    }
+    private throwValidationError(failureReason: FailureReason, tradeSide: TradeSide,
+                                 transferType: TransferType): Promise<never> {
+        const errMsg = ERR_MSG_MAPPING[failureReason][tradeSide][transferType];
+        throw new Error(errMsg);
+    }
+}

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -55,7 +55,8 @@ export class BalanceAndProxyAllowanceLazyStore {
             const balance = await this._token.getBalanceAsync(tokenAddress, userAddress);
             this.setBalance(tokenAddress, userAddress, balance);
         }
-        return this._balance[tokenAddress][userAddress];
+        const cachedBalance = this._balance[tokenAddress][userAddress];
+        return cachedBalance;
     }
     protected setBalance(tokenAddress: string, userAddress: string, balance: BigNumber.BigNumber): void {
         if (_.isUndefined(this._balance[tokenAddress])) {
@@ -69,7 +70,8 @@ export class BalanceAndProxyAllowanceLazyStore {
             const proxyAllowance = await this._token.getProxyAllowanceAsync(tokenAddress, userAddress);
             this.setProxyAllowance(tokenAddress, userAddress, proxyAllowance);
         }
-        return this._proxyAllowance[tokenAddress][userAddress];
+        const cachedProxyAllowance = this._proxyAllowance[tokenAddress][userAddress];
+        return cachedProxyAllowance;
     }
     protected setProxyAllowance(tokenAddress: string, userAddress: string, proxyAllowance: BigNumber.BigNumber): void {
         if (_.isUndefined(this._proxyAllowance[tokenAddress])) {

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -85,9 +85,9 @@ export class ExchangeTransferSimulator extends BalanceAndProxyAllowanceLazyStore
     /**
      * Simulates transferFrom call performed by a proxy
      * @param  tokenAddress      Address of the token to be transferred
-     * @param  from              Owner of the transfered tokens
-     * @param  to                Recipient of the transfered tokens
-     * @param  amountInBaseUnits The amount of tokens being transfered
+     * @param  from              Owner of the transferred tokens
+     * @param  to                Recipient of the transferred tokens
+     * @param  amountInBaseUnits The amount of tokens being transferred
      * @param  tradeSide         Is Maker/Taker transferring
      * @param  transferType      Is it a fee payment or a value transfer
      */

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -4,7 +4,7 @@ import {TokenWrapper} from '../contract_wrappers/token_wrapper';
 
 enum FailureReason {
     Balance = 'balance',
-    ProxyAllowance = 'proxy allowance',
+    ProxyAllowance = 'proxyAllowance',
 }
 
 const ERR_MSG_MAPPING = {

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -82,9 +82,6 @@ export class BalanceAndProxyAllowanceLazyStore {
 }
 
 export class ExchangeTransferSimulator extends BalanceAndProxyAllowanceLazyStore {
-    constructor(token: TokenWrapper) {
-        super(token);
-    }
     /**
      * Simulates transferFrom call performed by a proxy
      * @param  tokenAddress      Address of a token to be transfered

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -84,7 +84,7 @@ export class BalanceAndProxyAllowanceLazyStore {
 export class ExchangeTransferSimulator extends BalanceAndProxyAllowanceLazyStore {
     /**
      * Simulates transferFrom call performed by a proxy
-     * @param  tokenAddress      Address of a token to be transfered
+     * @param  tokenAddress      Address of the token to be transferred
      * @param  from              Owner of the transfered tokens
      * @param  to                Recipient of the transfered tokens
      * @param  amountInBaseUnits The amount of tokens being transfered

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -32,8 +32,6 @@ const ERR_MSG_MAPPING = {
 
 /**
  * Copy on read store for balances/proxyAllowances of tokens/accounts touched in trades
- * @param  {TokenWrapper} token [description]
- * @return {[type]}             [description]
  */
 export class BalanceAndProxyAllowanceLazyStore {
     protected _token: TokenWrapper;

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -96,11 +96,11 @@ export class ExchangeTransferSimulator extends BalanceAndProxyAllowanceLazyStore
                                    transferType: TransferType): Promise<void> {
         const balance = await this.getBalanceAsync(tokenAddress, from);
         const proxyAllowance = await this.getProxyAllowanceAsync(tokenAddress, from);
-        if (balance.lessThan(amountInBaseUnits)) {
-            this.throwValidationError(FailureReason.Balance, tradeSide, transferType);
-        }
         if (proxyAllowance.lessThan(amountInBaseUnits)) {
             this.throwValidationError(FailureReason.ProxyAllowance, tradeSide, transferType);
+        }
+        if (balance.lessThan(amountInBaseUnits)) {
+            this.throwValidationError(FailureReason.Balance, tradeSide, transferType);
         }
         await this.decreaseProxyAllowanceAsync(tokenAddress, from, amountInBaseUnits);
         await this.decreaseBalanceAsync(tokenAddress, from, amountInBaseUnits);

--- a/src/utils/exchange_transfer_simulator.ts
+++ b/src/utils/exchange_transfer_simulator.ts
@@ -104,9 +104,7 @@ export class ExchangeTransferSimulator extends BalanceAndProxyAllowanceLazyStore
         }
         await this.decreaseProxyAllowanceAsync(tokenAddress, from, amountInBaseUnits);
         await this.decreaseBalanceAsync(tokenAddress, from, amountInBaseUnits);
-        if (!_.isUndefined(to)) {
-            await this.increaseBalanceAsync(tokenAddress, to, amountInBaseUnits);
-        }
+        await this.increaseBalanceAsync(tokenAddress, to, amountInBaseUnits);
     }
     private async decreaseProxyAllowanceAsync(tokenAddress: string, userAddress: string,
                                               amountInBaseUnits: BigNumber.BigNumber): Promise<void> {

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -1,10 +1,11 @@
 import * as _ from 'lodash';
-import {ExchangeContractErrs, SignedOrder, Order, ZeroExError} from '../types';
+import {ExchangeContractErrs, SignedOrder, Order, ZeroExError, TradeSide, TransferType} from '../types';
 import {ZeroEx} from '../0x';
 import {TokenWrapper} from '../contract_wrappers/token_wrapper';
 import {ExchangeWrapper} from '../contract_wrappers/exchange_wrapper';
 import {utils} from '../utils/utils';
 import {constants} from '../utils/constants';
+import {ExchangeTransferSimulator} from './exchange_transfer_simulator';
 
 export class OrderValidationUtils {
     private tokenWrapper: TokenWrapper;
@@ -14,8 +15,8 @@ export class OrderValidationUtils {
         this.exchangeWrapper = exchangeWrapper;
     }
     public async validateOrderFillableOrThrowAsync(
-        signedOrder: SignedOrder, zrxTokenAddress: string, expectedFillTakerTokenAmount?: BigNumber.BigNumber,
-    ): Promise<void> {
+        exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder, zrxTokenAddress: string,
+        expectedFillTakerTokenAmount?: BigNumber.BigNumber): Promise<void> {
         const orderHash = utils.getOrderHashHex(signedOrder);
         const unavailableTakerTokenAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHash);
         this.validateRemainingFillAmountNotZeroOrThrow(
@@ -26,14 +27,20 @@ export class OrderValidationUtils {
         if (!_.isUndefined(expectedFillTakerTokenAmount)) {
             fillTakerTokenAmount = expectedFillTakerTokenAmount;
         }
-        await this.validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
-            signedOrder, fillTakerTokenAmount, zrxTokenAddress,
+        const fillMakerTokenAmount = this.getFillMakerTokenAmount(signedOrder, fillTakerTokenAmount);
+        await exchangeTradeEmulator.transferFromAsync(
+            signedOrder.makerTokenAddress, signedOrder.maker, signedOrder.taker, fillMakerTokenAmount,
+            TradeSide.Maker, TransferType.Trade,
+        );
+        await exchangeTradeEmulator.transferFromAsync(
+            zrxTokenAddress, signedOrder.maker, signedOrder.feeRecipient, signedOrder.makerFee,
+            TradeSide.Maker, TransferType.Fee,
         );
     }
-    public async validateFillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                      fillTakerTokenAmount: BigNumber.BigNumber,
-                                                      takerAddress: string,
-                                                      zrxTokenAddress: string): Promise<void> {
+    public async validateFillOrderThrowIfInvalidAsync(
+        exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder,
+        fillTakerTokenAmount: BigNumber.BigNumber, takerAddress: string,
+        zrxTokenAddress: string): Promise<BigNumber.BigNumber> {
         if (fillTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderFillAmountZero);
         }
@@ -49,29 +56,29 @@ export class OrderValidationUtils {
             throw new Error(ExchangeContractErrs.TransactionSenderIsNotFillOrderTaker);
         }
         this.validateOrderNotExpiredOrThrow(signedOrder.expirationUnixTimestampSec);
+        const remainingTakerTokenAmount = signedOrder.takerTokenAmount.minus(unavailableTakerTokenAmount);
+        const filledTakerTokenAmount = remainingTakerTokenAmount.lessThan(fillTakerTokenAmount) ?
+                                       remainingTakerTokenAmount :
+                                       fillTakerTokenAmount;
         await this.validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
-            signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
+            exchangeTradeEmulator, signedOrder, filledTakerTokenAmount, takerAddress, zrxTokenAddress,
         );
 
         const wouldRoundingErrorOccur = await this.exchangeWrapper.isRoundingErrorAsync(
-            fillTakerTokenAmount, signedOrder.takerTokenAmount, signedOrder.makerTokenAmount,
+            filledTakerTokenAmount, signedOrder.takerTokenAmount, signedOrder.makerTokenAmount,
         );
         if (wouldRoundingErrorOccur) {
             throw new Error(ExchangeContractErrs.OrderFillRoundingError);
         }
+        return filledTakerTokenAmount;
     }
-    public async validateFillOrKillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                            fillTakerTokenAmount: BigNumber.BigNumber,
-                                                            takerAddress: string,
-                                                            zrxTokenAddress: string): Promise<void> {
-        await this.validateFillOrderThrowIfInvalidAsync(
-            signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
+    public async validateFillOrKillOrderThrowIfInvalidAsync(
+        exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder,
+        fillTakerTokenAmount: BigNumber.BigNumber, takerAddress: string, zrxTokenAddress: string): Promise<void> {
+        const filledTakerTokenAmount = await this.validateFillOrderThrowIfInvalidAsync(
+            exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
         );
-        // Check that fillValue available >= fillTakerAmount
-        const orderHashHex = utils.getOrderHashHex(signedOrder);
-        const unavailableTakerAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHashHex);
-        const remainingTakerAmount = signedOrder.takerTokenAmount.minus(unavailableTakerAmount);
-        if (remainingTakerAmount < fillTakerTokenAmount) {
+        if (filledTakerTokenAmount !== fillTakerTokenAmount) {
             throw new Error(ExchangeContractErrs.InsufficientRemainingFillAmount);
         }
     }
@@ -91,87 +98,25 @@ export class OrderValidationUtils {
         }
     }
     public async validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
-        signedOrder: SignedOrder, fillTakerAmount: BigNumber.BigNumber, senderAddress: string, zrxTokenAddress: string,
-    ): Promise<void> {
-        await this.validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
-            signedOrder, fillTakerAmount, zrxTokenAddress,
+        exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder,
+        fillTakerTokenAmount: BigNumber.BigNumber, senderAddress: string, zrxTokenAddress: string): Promise<void> {
+        const fillMakerTokenAmount = this.getFillMakerTokenAmount(signedOrder, fillTakerTokenAmount);
+        await exchangeTradeEmulator.transferFromAsync(
+            signedOrder.makerTokenAddress, signedOrder.maker, signedOrder.taker, fillMakerTokenAmount,
+            TradeSide.Maker, TransferType.Trade,
         );
-        await this.validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-            signedOrder, fillTakerAmount, senderAddress, zrxTokenAddress,
+        await exchangeTradeEmulator.transferFromAsync(
+            signedOrder.takerTokenAddress, signedOrder.taker, signedOrder.maker, fillTakerTokenAmount,
+            TradeSide.Taker, TransferType.Trade,
         );
-    }
-    private async validateFillOrderMakerBalancesAllowancesThrowIfInvalidAsync(
-        signedOrder: SignedOrder, fillTakerAmount: BigNumber.BigNumber, zrxTokenAddress: string,
-    ): Promise<void> {
-        const makerBalance = await this.tokenWrapper.getBalanceAsync(signedOrder.makerTokenAddress, signedOrder.maker);
-        const makerAllowance = await this.tokenWrapper.getProxyAllowanceAsync(
-            signedOrder.makerTokenAddress, signedOrder.maker);
-
-        const isMakerTokenZRX = signedOrder.makerTokenAddress === zrxTokenAddress;
-        // exchangeRate is the price of one maker token denominated in taker tokens
-        const exchangeRate = signedOrder.takerTokenAmount.div(signedOrder.makerTokenAmount);
-        const fillMakerAmount = fillTakerAmount.div(exchangeRate);
-
-        const requiredMakerAmount = isMakerTokenZRX ? fillMakerAmount.plus(signedOrder.makerFee) : fillMakerAmount;
-        if (requiredMakerAmount.greaterThan(makerBalance)) {
-            throw new Error(ExchangeContractErrs.InsufficientMakerBalance);
-        }
-        if (requiredMakerAmount.greaterThan(makerAllowance)) {
-            throw new Error(ExchangeContractErrs.InsufficientMakerAllowance);
-        }
-
-        if (!isMakerTokenZRX) {
-            let makerZRXBalance = await this.tokenWrapper.getBalanceAsync(zrxTokenAddress, signedOrder.maker);
-            const isTakerTokenZRX = signedOrder.takerTokenAddress === zrxTokenAddress;
-            if (isTakerTokenZRX) {
-                makerZRXBalance = makerZRXBalance.plus(fillTakerAmount);
-            }
-            const makerZRXAllowance = await this.tokenWrapper.getProxyAllowanceAsync(
-                zrxTokenAddress, signedOrder.maker);
-
-            if (signedOrder.makerFee.greaterThan(makerZRXBalance)) {
-                throw new Error(ExchangeContractErrs.InsufficientMakerFeeBalance);
-            }
-            if (signedOrder.makerFee.greaterThan(makerZRXAllowance)) {
-                throw new Error(ExchangeContractErrs.InsufficientMakerFeeAllowance);
-            }
-        }
-    }
-    private async validateFillOrderTakerBalancesAllowancesThrowIfInvalidAsync(
-        signedOrder: SignedOrder, fillTakerAmount: BigNumber.BigNumber, senderAddress: string, zrxTokenAddress: string,
-    ): Promise<void> {
-        const takerBalance = await this.tokenWrapper.getBalanceAsync(signedOrder.takerTokenAddress, senderAddress);
-        const takerAllowance = await this.tokenWrapper.getProxyAllowanceAsync(
-            signedOrder.takerTokenAddress, senderAddress);
-
-        const isTakerTokenZRX = signedOrder.takerTokenAddress === zrxTokenAddress;
-        // exchangeRate is the price of one maker token denominated in taker tokens
-        const exchangeRate = signedOrder.takerTokenAmount.div(signedOrder.makerTokenAmount);
-        const fillMakerAmount = fillTakerAmount.div(exchangeRate);
-
-        const requiredTakerAmount = isTakerTokenZRX ? fillTakerAmount.plus(signedOrder.takerFee) : fillTakerAmount;
-        if (requiredTakerAmount.greaterThan(takerBalance)) {
-            throw new Error(ExchangeContractErrs.InsufficientTakerBalance);
-        }
-        if (requiredTakerAmount.greaterThan(takerAllowance)) {
-            throw new Error(ExchangeContractErrs.InsufficientTakerAllowance);
-        }
-
-        if (!isTakerTokenZRX) {
-            const isMakerTokenZRX = signedOrder.makerTokenAddress === zrxTokenAddress;
-            let takerZRXBalance = await this.tokenWrapper.getBalanceAsync(zrxTokenAddress, senderAddress);
-            if (isMakerTokenZRX) {
-                takerZRXBalance = takerZRXBalance.plus(fillMakerAmount);
-            }
-            const takerZRXAllowance = await this.tokenWrapper.getProxyAllowanceAsync(zrxTokenAddress, senderAddress);
-
-            if (signedOrder.takerFee.greaterThan(takerZRXBalance)) {
-                throw new Error(ExchangeContractErrs.InsufficientTakerFeeBalance);
-            }
-            if (signedOrder.takerFee.greaterThan(takerZRXAllowance)) {
-                throw new Error(ExchangeContractErrs.InsufficientTakerFeeAllowance);
-            }
-        }
+        await exchangeTradeEmulator.transferFromAsync(
+            zrxTokenAddress, signedOrder.maker, signedOrder.feeRecipient, signedOrder.makerFee, TradeSide.Maker,
+            TransferType.Fee,
+        );
+        await exchangeTradeEmulator.transferFromAsync(
+            zrxTokenAddress, signedOrder.taker, signedOrder.feeRecipient, signedOrder.takerFee, TradeSide.Taker,
+            TransferType.Fee,
+        );
     }
     private validateRemainingFillAmountNotZeroOrThrow(
         takerTokenAmount: BigNumber.BigNumber, unavailableTakerTokenAmount: BigNumber.BigNumber,
@@ -185,5 +130,11 @@ export class OrderValidationUtils {
         if (expirationUnixTimestampSec.lessThan(currentUnixTimestampSec)) {
             throw new Error(ExchangeContractErrs.OrderFillExpired);
         }
+    }
+    private getFillMakerTokenAmount(signedOrder: Order,
+                                    fillTakerTokenAmount: BigNumber.BigNumber): BigNumber.BigNumber {
+        const exchangeRate = signedOrder.takerTokenAmount.div(signedOrder.makerTokenAmount);
+        const fillMakerTokenAmount = fillTakerTokenAmount.div(exchangeRate);
+        return fillMakerTokenAmount;
     }
 }

--- a/test/exchange_transfer_simulator_test.ts
+++ b/test/exchange_transfer_simulator_test.ts
@@ -1,0 +1,91 @@
+import * as chai from 'chai';
+import * as BigNumber from 'bignumber.js';
+import * as Web3 from 'web3';
+import {chaiSetup} from './utils/chai_setup';
+import {web3Factory} from './utils/web3_factory';
+import {ZeroEx, SignedOrder, ExchangeContractErrs, Token} from '../src';
+import {TradeSide, TransferType} from '../src/types';
+import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
+import {FillScenarios} from './utils/fill_scenarios';
+import {ExchangeTransferSimulator} from '../src/utils/exchange_transfer_simulator';
+
+chaiSetup.configure();
+const expect = chai.expect;
+const blockchainLifecycle = new BlockchainLifecycle();
+
+describe('ExchangeTransferSimulator', () => {
+    const web3 = web3Factory.create();
+    const zeroEx = new ZeroEx(web3.currentProvider);
+    const transferAmount = new BigNumber(5);
+    let userAddresses: string[];
+    let tokens: Token[];
+    let coinbase: string;
+    let sender: string;
+    let recipient: string;
+    let exampleTokenAddress: string;
+    let exchangeTransferSimulator: ExchangeTransferSimulator;
+    let txHash: string;
+    before(async () => {
+        userAddresses = await zeroEx.getAvailableAddressesAsync();
+        [coinbase, sender, recipient] = userAddresses;
+        tokens = await zeroEx.tokenRegistry.getTokensAsync();
+        exampleTokenAddress = tokens[0].address;
+    });
+    beforeEach(async () => {
+        await blockchainLifecycle.startAsync();
+    });
+    afterEach(async () => {
+        await blockchainLifecycle.revertAsync();
+    });
+    describe('#transferFromAsync', () => {
+        beforeEach(() => {
+            exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token);
+        });
+        it('throws if the user doesn\'t have enough balance', async () => {
+            return expect(exchangeTransferSimulator.transferFromAsync(
+                exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Maker, TransferType.Trade,
+            )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerBalance);
+        });
+        it('throws if the user doesn\'t have enough allowance', async () => {
+            txHash = await zeroEx.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);
+            await zeroEx.awaitTransactionMinedAsync(txHash);
+            return expect(exchangeTransferSimulator.transferFromAsync(
+                exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Taker, TransferType.Trade,
+            )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerAllowance);
+        });
+        it('updates balances and proxyAllowance after transfer', async () => {
+            txHash = await zeroEx.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);
+            await zeroEx.awaitTransactionMinedAsync(txHash);
+            txHash = await zeroEx.token.setProxyAllowanceAsync(exampleTokenAddress, sender, transferAmount);
+            await zeroEx.awaitTransactionMinedAsync(txHash);
+            await exchangeTransferSimulator.transferFromAsync(
+                exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Taker, TransferType.Trade,
+            );
+            const senderBalance = await (exchangeTransferSimulator as any).getBalanceAsync(exampleTokenAddress, sender);
+            const recipientBalance = await (exchangeTransferSimulator as any).getBalanceAsync(
+                exampleTokenAddress, recipient);
+            const senderProxyAllowance = await (exchangeTransferSimulator as any).getProxyAllowanceAsync(
+                exampleTokenAddress, sender);
+            expect(senderBalance).to.be.bignumber.equal(0);
+            expect(recipientBalance).to.be.bignumber.equal(transferAmount);
+            expect(senderProxyAllowance).to.be.bignumber.equal(0);
+        });
+        it('doesn\'t update proxyAllowance after transfer if unlimited', async () => {
+            txHash = await zeroEx.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);
+            await zeroEx.awaitTransactionMinedAsync(txHash);
+            txHash = await zeroEx.token.setUnlimitedProxyAllowanceAsync(exampleTokenAddress, sender);
+            await zeroEx.awaitTransactionMinedAsync(txHash);
+            await exchangeTransferSimulator.transferFromAsync(
+                exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Taker, TransferType.Trade,
+            );
+            const senderBalance = await (exchangeTransferSimulator as any).getBalanceAsync(exampleTokenAddress, sender);
+            const recipientBalance = await (exchangeTransferSimulator as any).getBalanceAsync(
+                exampleTokenAddress, recipient);
+            const senderProxyAllowance = await (exchangeTransferSimulator as any).getProxyAllowanceAsync(
+                exampleTokenAddress, sender);
+            expect(senderBalance).to.be.bignumber.equal(0);
+            expect(recipientBalance).to.be.bignumber.equal(transferAmount);
+            expect(senderProxyAllowance).to.be.bignumber.equal(zeroEx.token.UNLIMITED_ALLOWANCE_IN_BASE_UNITS);
+        });
+    });
+});

--- a/test/exchange_transfer_simulator_test.ts
+++ b/test/exchange_transfer_simulator_test.ts
@@ -41,17 +41,17 @@ describe('ExchangeTransferSimulator', () => {
         beforeEach(() => {
             exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token);
         });
-        it('throws if the user doesn\'t have enough balance', async () => {
-            return expect(exchangeTransferSimulator.transferFromAsync(
-                exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Maker, TransferType.Trade,
-            )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerBalance);
-        });
         it('throws if the user doesn\'t have enough allowance', async () => {
-            txHash = await zeroEx.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);
-            await zeroEx.awaitTransactionMinedAsync(txHash);
             return expect(exchangeTransferSimulator.transferFromAsync(
                 exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Taker, TransferType.Trade,
             )).to.be.rejectedWith(ExchangeContractErrs.InsufficientTakerAllowance);
+        });
+        it('throws if the user doesn\'t have enough balance', async () => {
+            txHash = await zeroEx.token.setProxyAllowanceAsync(exampleTokenAddress, sender, transferAmount);
+            await zeroEx.awaitTransactionMinedAsync(txHash);
+            return expect(exchangeTransferSimulator.transferFromAsync(
+                exampleTokenAddress, sender, recipient, transferAmount, TradeSide.Maker, TransferType.Trade,
+            )).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerBalance);
         });
         it('updates balances and proxyAllowance after transfer', async () => {
             txHash = await zeroEx.token.transferAsync(exampleTokenAddress, coinbase, sender, transferAmount);


### PR DESCRIPTION
This PR:
* Emulates the actual transfers on a copy-on-read balance/proxyAllowance store to perform validations for batch operations
* Fixes the ETH address validation
* Stops using public validations functions for internal validations and starts using utils
