### PR TITLE
Fix a bug in logs fetching

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-v0.21.0 - _TBD, 2017_
+v0.21.1 - _October 11, 2017_
+------------------------
+    * Fixed a bug in subscriptions (#189)
+
+v0.21.0 - _October 10, 2017_
 ------------------------
     * Complete rewrite of subscription logic (#182)
         * Subscriptions no longer return historical logs. If you want them - use `getLogsAsync`

--- a/src/web3_wrapper.ts
+++ b/src/web3_wrapper.ts
@@ -107,11 +107,24 @@ export class Web3Wrapper {
         return addresses;
     }
     public async getLogsAsync(filter: Web3.FilterObject): Promise<Web3.LogEntry[]> {
+        let fromBlock = filter.fromBlock;
+        if (_.isNumber(fromBlock)) {
+            fromBlock = this.web3.toHex(fromBlock);
+        }
+        let toBlock = filter.toBlock;
+        if (_.isNumber(toBlock)) {
+            toBlock = this.web3.toHex(toBlock);
+        }
+        const serializedFilter = {
+            ...filter,
+            fromBlock,
+            toBlock,
+        };
         const payload = {
             jsonrpc: '2.0',
             id: this.jsonRpcRequestId++,
             method: 'eth_getLogs',
-            params: [filter],
+            params: [serializedFilter],
         };
         const logs = await this.sendRawPayloadAsync(payload);
         return logs;


### PR DESCRIPTION
This PR:
* Fixes a bug when 0x.js sent an RPC request with `fromBlock` and `toBlock` as integers instead of hexes.
* testrpc supports number values, but it's not a part of a standard.
* Fixes #188 