### PR TITLE
Fix rounding of maker fill amount and correctly validate partial fees

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+v0.22.2 - _October 24, 2017_
+------------------------
+    * Fixed rounding of maker fill amount and incorrect validation of partial fees (#197)
+
 v0.22.0 - _October 16, 2017_
 ------------------------
     * Started using `OrderFillRequest` interface instead of `OrderFillOrKillRequest` interface for `zeroEx.exchange.batchFillOrKill` (#187)

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -301,7 +301,8 @@ describe('OrderValidation', () => {
                 exchangeTransferSimulator, signedOrder, takerTokenAmount, takerAddress, zrxTokenAddress,
             );
             expect(transferFromAsync.callCount).to.be.equal(4);
-            expect(transferFromAsync.getCall(0).args[3]).to.be.bignumber.equal(makerTokenAmount);
+            const makerFillAmount = transferFromAsync.getCall(0).args[3];
+            expect(makerFillAmount).to.be.bignumber.equal(makerTokenAmount);
         });
         it('should correctly round the makerFeeAmount', async () => {
             const makerFee = new BigNumber(2);
@@ -317,8 +318,10 @@ describe('OrderValidation', () => {
             const makerPartialFee = makerFee.div(2);
             const takerPartialFee = takerFee.div(2);
             expect(transferFromAsync.callCount).to.be.equal(4);
-            expect(transferFromAsync.getCall(2).args[3]).to.be.bignumber.equal(makerPartialFee);
-            expect(transferFromAsync.getCall(4).args[3]).to.be.bignumber.equal(takerPartialFee);
+            const partialMakerFee = transferFromAsync.getCall(2).args[3];
+            expect(partialMakerFee).to.be.bignumber.equal(makerPartialFee);
+            const partialTakerFee = transferFromAsync.getCall(4).args[3];
+            expect(partialTakerFee).to.be.bignumber.equal(takerPartialFee);
         });
     });
 });

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -320,7 +320,7 @@ describe('OrderValidation', () => {
             expect(transferFromAsync.callCount).to.be.equal(4);
             const partialMakerFee = transferFromAsync.getCall(2).args[3];
             expect(partialMakerFee).to.be.bignumber.equal(makerPartialFee);
-            const partialTakerFee = transferFromAsync.getCall(4).args[3];
+            const partialTakerFee = transferFromAsync.getCall(3).args[3];
             expect(partialTakerFee).to.be.bignumber.equal(takerPartialFee);
         });
     });

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -210,14 +210,14 @@ describe('OrderValidation', () => {
     });
     describe('#validateFillOrderBalancesAllowancesThrowIfInvalidAsync', () => {
         let exchangeTransferSimulator: ExchangeTransferSimulator;
-        let transferFromAsync: any;
+        let transferFromAsync: Sinon.SinonSpy;
         const bigNumberMatch = (expected: BigNumber.BigNumber) => {
             return Sinon.match((value: BigNumber.BigNumber) => value.eq(expected));
         };
         beforeEach('create exchangeTransferSimulator', async () => {
             exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token);
             transferFromAsync = Sinon.spy();
-            exchangeTransferSimulator.transferFromAsync = transferFromAsync;
+            exchangeTransferSimulator.transferFromAsync = transferFromAsync as any;
         });
         it('should call exchangeTransferSimulator.transferFrom in a correct order', async () => {
             const makerFee = new BigNumber(2);
@@ -290,6 +290,35 @@ describe('OrderValidation', () => {
                     TradeSide.Taker, TransferType.Fee,
                 ),
             ).to.be.true();
+        });
+        it('should correctly round the fillMakerTokenAmount', async () => {
+            const makerTokenAmount = new BigNumber(3);
+            const takerTokenAmount = new BigNumber(1);
+            const signedOrder = await fillScenarios.createAsymmetricFillableSignedOrderAsync(
+                makerTokenAddress, takerTokenAddress, makerAddress, takerAddress, makerTokenAmount, takerTokenAmount,
+            );
+            await orderValidationUtils.validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
+                exchangeTransferSimulator, signedOrder, takerTokenAmount, takerAddress, zrxTokenAddress,
+            );
+            expect(transferFromAsync.callCount).to.be.equal(4);
+            expect(transferFromAsync.getCall(0).args[3]).to.be.bignumber.equal(makerTokenAmount);
+        });
+        it('should correctly round the makerFeeAmount', async () => {
+            const makerFee = new BigNumber(2);
+            const takerFee = new BigNumber(4);
+            const signedOrder = await fillScenarios.createFillableSignedOrderWithFeesAsync(
+                makerTokenAddress, takerTokenAddress, makerFee, takerFee, makerAddress, takerAddress,
+                fillableAmount, ZeroEx.NULL_ADDRESS,
+            );
+            const fillTakerTokenAmount = fillableAmount.div(2).round(0);
+            await orderValidationUtils.validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
+                exchangeTransferSimulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
+            );
+            const makerPartialFee = makerFee.div(2);
+            const takerPartialFee = takerFee.div(2);
+            expect(transferFromAsync.callCount).to.be.equal(4);
+            expect(transferFromAsync.getCall(2).args[3]).to.be.bignumber.equal(makerPartialFee);
+            expect(transferFromAsync.getCall(4).args[3]).to.be.bignumber.equal(takerPartialFee);
         });
     });
 });


### PR DESCRIPTION
This PR:
* Fixes the rounding issue when calculating `maker fill amount`
* Correctly validates fees within a partial fill
* Adds regression tests for the bugs above