### PR TITLE
Increase ALLOWANCE_TO_ZERO_GAS_AMOUNT

### DIFF
--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -19,7 +19,7 @@ import {
     TokenContractEventArgs,
 } from '../types';
 
-const ALLOWANCE_TO_ZERO_GAS_AMOUNT = 47155;
+const ALLOWANCE_TO_ZERO_GAS_AMOUNT = 47275;
 
 /**
  * This class includes all the functionality related to interacting with ERC20 token contracts.


### PR DESCRIPTION
On TestRPC, I'm seeing a particular transaction that is taking 47275
gas instead of the predefined 47155. It's not at all obvious to me
why this transaction is taking an extra 120 gas, and I've been unable
to reproduce the issue in the 0x.js test suite, but bumping the gas
allowance has resolved the issue for me.

The transactions in question are trying to set an unlimited proxy
allowance on either the WETH or ZRX tokens in the testrpc snapshot,
but run out of gas.

This PR:
* Raises the ALLOWANCE_TO_ZERO_GAS_AMOUNT based on values I'm seeing with ethereumjs-testrpc@4.1.3
