### PR TITLE
Bignumber types

### DIFF
--- a/package.json
+++ b/package.json
@@ -91,8 +91,7 @@
   },
   "dependencies": {
     "0x-json-schemas": "^0.6.1",
-    "@types/bignumber.js": "^4.0.2",
-    "bignumber.js": "^4.0.2",
+    "bignumber.js": "^4.1.0",
     "compare-versions": "^3.0.1",
     "es6-promisify": "^5.0.0",
     "ethereumjs-abi": "^0.6.4",

--- a/package.json
+++ b/package.json
@@ -81,7 +81,7 @@
     "truffle-hdwallet-provider": "^0.0.3",
     "tslint": "^5.3.2",
     "tslint-config-0xproject": "^0.0.2",
-    "typedoc": "^0.9.0",
+    "typedoc": "~0.8.0",
     "types-bn": "^0.0.1",
     "types-ethereumjs-util": "0xProject/types-ethereumjs-util",
     "typescript": "^2.4.1",

--- a/src/0x.ts
+++ b/src/0x.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {SchemaValidator, schemas} from '0x-json-schemas';
 import {bigNumberConfigs} from './bignumber_config';
 import * as ethUtil from 'ethereumjs-util';
@@ -100,7 +100,7 @@ export class ZeroEx {
      * and will not collide with other outstanding orders that are identical in all other parameters.
      * @return  A pseudo-random 256-bit number that can be used as a salt.
      */
-    public static generatePseudoRandomSalt(): BigNumber.BigNumber {
+    public static generatePseudoRandomSalt(): BigNumber {
         // BigNumber.random returns a pseudo-random number between 0 & 1 with a passed in number of decimal places.
         // Source: https://mikemcl.github.io/bignumber.js/#random
         const randomNumber = BigNumber.random(constants.MAX_DIGITS_IN_UNSIGNED_256_INT);
@@ -131,7 +131,7 @@ export class ZeroEx {
      * @param   decimals    The number of decimal places the unit amount has.
      * @return  The amount in units.
      */
-    public static toUnitAmount(amount: BigNumber.BigNumber, decimals: number): BigNumber.BigNumber {
+    public static toUnitAmount(amount: BigNumber, decimals: number): BigNumber {
         assert.isBigNumber('amount', amount);
         assert.isNumber('decimals', decimals);
 
@@ -147,7 +147,7 @@ export class ZeroEx {
      * @param   decimals    The number of decimal places the unit amount has.
      * @return  The amount in baseUnits.
      */
-    public static toBaseUnitAmount(amount: BigNumber.BigNumber, decimals: number): BigNumber.BigNumber {
+    public static toBaseUnitAmount(amount: BigNumber, decimals: number): BigNumber {
         assert.isBigNumber('amount', amount);
         assert.isNumber('decimals', decimals);
 

--- a/src/bignumber_config.ts
+++ b/src/bignumber_config.ts
@@ -1,4 +1,4 @@
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
 export const bigNumberConfigs = {
     configure() {

--- a/src/contract_wrappers/ether_token_wrapper.ts
+++ b/src/contract_wrappers/ether_token_wrapper.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import BigNumber from 'bignumber.js';
 import {Web3Wrapper} from '../web3_wrapper';
 import {ContractWrapper} from './contract_wrapper';
 import {TokenWrapper} from './token_wrapper';
@@ -27,7 +28,7 @@ export class EtherTokenWrapper extends ContractWrapper {
      * @param   depositor   The hex encoded user Ethereum address that would like to make the deposit.
      * @return Transaction hash.
      */
-    public async depositAsync(amountInWei: BigNumber.BigNumber, depositor: string): Promise<string> {
+    public async depositAsync(amountInWei: BigNumber, depositor: string): Promise<string> {
         assert.isBigNumber('amountInWei', amountInWei);
         await assert.isSenderAddressAsync('depositor', depositor, this._web3Wrapper);
 
@@ -48,7 +49,7 @@ export class EtherTokenWrapper extends ContractWrapper {
      * @param   withdrawer   The hex encoded user Ethereum address that would like to make the withdrawl.
      * @return Transaction hash.
      */
-    public async withdrawAsync(amountInWei: BigNumber.BigNumber, withdrawer: string): Promise<string> {
+    public async withdrawAsync(amountInWei: BigNumber, withdrawer: string): Promise<string> {
         assert.isBigNumber('amountInWei', amountInWei);
         await assert.isSenderAddressAsync('withdrawer', withdrawer, this._web3Wrapper);
 

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as Web3 from 'web3';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {schemas} from '0x-json-schemas';
 import {Web3Wrapper} from '../web3_wrapper';
 import {
@@ -97,7 +97,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @return  The amount of the order (in taker tokens) that has either been filled or canceled.
      */
     public async getUnavailableTakerAmountAsync(orderHash: string,
-                                                methodOpts?: MethodOpts): Promise<BigNumber.BigNumber> {
+                                                methodOpts?: MethodOpts): Promise<BigNumber> {
         assert.doesConformToSchema('orderHash', orderHash, schemas.orderHashSchema);
 
         const exchangeContract = await this._getExchangeContractAsync();
@@ -115,7 +115,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   methodOpts   Optional arguments this method accepts.
      * @return  The amount of the order (in taker tokens) that has already been filled.
      */
-    public async getFilledTakerAmountAsync(orderHash: string, methodOpts?: MethodOpts): Promise<BigNumber.BigNumber> {
+    public async getFilledTakerAmountAsync(orderHash: string, methodOpts?: MethodOpts): Promise<BigNumber> {
         assert.doesConformToSchema('orderHash', orderHash, schemas.orderHashSchema);
 
         const exchangeContract = await this._getExchangeContractAsync();
@@ -132,7 +132,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   methodOpts   Optional arguments this method accepts.
      * @return  The amount of the order (in taker tokens) that has been cancelled.
      */
-    public async getCanceledTakerAmountAsync(orderHash: string, methodOpts?: MethodOpts): Promise<BigNumber.BigNumber> {
+    public async getCanceledTakerAmountAsync(orderHash: string, methodOpts?: MethodOpts): Promise<BigNumber> {
         assert.doesConformToSchema('orderHash', orderHash, schemas.orderHashSchema);
 
         const exchangeContract = await this._getExchangeContractAsync();
@@ -162,7 +162,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @return  Transaction hash.
      */
     @decorators.contractCallErrorHandler
-    public async fillOrderAsync(signedOrder: SignedOrder, fillTakerTokenAmount: BigNumber.BigNumber,
+    public async fillOrderAsync(signedOrder: SignedOrder, fillTakerTokenAmount: BigNumber,
                                 shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                                 takerAddress: string,
                                 orderTransactionOpts?: OrderTransactionOpts): Promise<string> {
@@ -229,7 +229,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @return  Transaction hash.
      */
     @decorators.contractCallErrorHandler
-    public async fillOrdersUpToAsync(signedOrders: SignedOrder[], fillTakerTokenAmount: BigNumber.BigNumber,
+    public async fillOrdersUpToAsync(signedOrders: SignedOrder[], fillTakerTokenAmount: BigNumber,
                                      shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                                      takerAddress: string,
                                      orderTransactionOpts?: OrderTransactionOpts): Promise<string> {
@@ -405,7 +405,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @return  Transaction hash.
      */
     @decorators.contractCallErrorHandler
-    public async fillOrKillOrderAsync(signedOrder: SignedOrder, fillTakerTokenAmount: BigNumber.BigNumber,
+    public async fillOrKillOrderAsync(signedOrder: SignedOrder, fillTakerTokenAmount: BigNumber,
                                       takerAddress: string,
                                       orderTransactionOpts?: OrderTransactionOpts): Promise<string> {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
@@ -541,7 +541,7 @@ export class ExchangeWrapper extends ContractWrapper {
      */
     @decorators.contractCallErrorHandler
     public async cancelOrderAsync(order: Order|SignedOrder,
-                                  cancelTakerTokenAmount: BigNumber.BigNumber,
+                                  cancelTakerTokenAmount: BigNumber,
                                   orderTransactionOpts?: OrderTransactionOpts): Promise<string> {
         assert.doesConformToSchema('order', order, schemas.orderSchema);
         assert.isBigNumber('takerTokenCancelAmount', cancelTakerTokenAmount);
@@ -736,7 +736,7 @@ export class ExchangeWrapper extends ContractWrapper {
      *                                  Must be available via the supplied Web3.Provider passed to 0x.js.
      */
     public async validateFillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                      fillTakerTokenAmount: BigNumber.BigNumber,
+                                                      fillTakerTokenAmount: BigNumber,
                                                       takerAddress: string): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
         assert.isBigNumber('fillTakerTokenAmount', fillTakerTokenAmount);
@@ -753,7 +753,7 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   cancelTakerTokenAmount  The amount (specified in taker tokens) that you would like to cancel.
      */
     public async validateCancelOrderThrowIfInvalidAsync(
-        order: Order, cancelTakerTokenAmount: BigNumber.BigNumber): Promise<void> {
+        order: Order, cancelTakerTokenAmount: BigNumber): Promise<void> {
         assert.doesConformToSchema('order', order, schemas.orderSchema);
         assert.isBigNumber('cancelTakerTokenAmount', cancelTakerTokenAmount);
         const orderHash = utils.getOrderHashHex(order);
@@ -770,7 +770,7 @@ export class ExchangeWrapper extends ContractWrapper {
      *                                  Must be available via the supplied Web3.Provider passed to 0x.js.
      */
     public async validateFillOrKillOrderThrowIfInvalidAsync(signedOrder: SignedOrder,
-                                                            fillTakerTokenAmount: BigNumber.BigNumber,
+                                                            fillTakerTokenAmount: BigNumber,
                                                             takerAddress: string): Promise<void> {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
         assert.isBigNumber('fillTakerTokenAmount', fillTakerTokenAmount);
@@ -789,9 +789,9 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   takerTokenAmount       The order size on the taker side
      * @param   makerTokenAmount       The order size on the maker side
      */
-    public async isRoundingErrorAsync(fillTakerTokenAmount: BigNumber.BigNumber,
-                                      takerTokenAmount: BigNumber.BigNumber,
-                                      makerTokenAmount: BigNumber.BigNumber): Promise<boolean> {
+    public async isRoundingErrorAsync(fillTakerTokenAmount: BigNumber,
+                                      takerTokenAmount: BigNumber,
+                                      makerTokenAmount: BigNumber): Promise<boolean> {
         assert.isBigNumber('fillTakerTokenAmount', fillTakerTokenAmount);
         assert.isBigNumber('takerTokenAmount', takerTokenAmount);
         assert.isBigNumber('makerTokenAmount', makerTokenAmount);

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {schemas} from '0x-json-schemas';
 import {Web3Wrapper} from '../web3_wrapper';
 import {assert} from '../utils/assert';
@@ -46,7 +46,7 @@ export class TokenWrapper extends ContractWrapper {
      * @return  The owner's ERC20 token balance in base units.
      */
     public async getBalanceAsync(tokenAddress: string, ownerAddress: string,
-                                 methodOpts?: MethodOpts): Promise<BigNumber.BigNumber> {
+                                 methodOpts?: MethodOpts): Promise<BigNumber> {
         assert.isETHAddressHex('ownerAddress', ownerAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
 
@@ -68,7 +68,7 @@ export class TokenWrapper extends ContractWrapper {
      * @return Transaction hash.
      */
     public async setAllowanceAsync(tokenAddress: string, ownerAddress: string, spenderAddress: string,
-                                   amountInBaseUnits: BigNumber.BigNumber): Promise<string> {
+                                   amountInBaseUnits: BigNumber): Promise<string> {
         await assert.isSenderAddressAsync('ownerAddress', ownerAddress, this._web3Wrapper);
         assert.isETHAddressHex('spenderAddress', spenderAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
@@ -113,7 +113,7 @@ export class TokenWrapper extends ContractWrapper {
      * @param   methodOpts      Optional arguments this method accepts.
      */
     public async getAllowanceAsync(tokenAddress: string, ownerAddress: string,
-                                   spenderAddress: string, methodOpts?: MethodOpts): Promise<BigNumber.BigNumber> {
+                                   spenderAddress: string, methodOpts?: MethodOpts): Promise<BigNumber> {
         assert.isETHAddressHex('ownerAddress', ownerAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
 
@@ -131,7 +131,7 @@ export class TokenWrapper extends ContractWrapper {
      * @param   methodOpts      Optional arguments this method accepts.
      */
     public async getProxyAllowanceAsync(tokenAddress: string, ownerAddress: string,
-                                        methodOpts?: MethodOpts): Promise<BigNumber.BigNumber> {
+                                        methodOpts?: MethodOpts): Promise<BigNumber> {
         assert.isETHAddressHex('ownerAddress', ownerAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
 
@@ -149,7 +149,7 @@ export class TokenWrapper extends ContractWrapper {
      * @return Transaction hash.
      */
     public async setProxyAllowanceAsync(tokenAddress: string, ownerAddress: string,
-                                        amountInBaseUnits: BigNumber.BigNumber): Promise<string> {
+                                        amountInBaseUnits: BigNumber): Promise<string> {
         assert.isETHAddressHex('ownerAddress', ownerAddress);
         assert.isETHAddressHex('tokenAddress', tokenAddress);
         assert.isBigNumber('amountInBaseUnits', amountInBaseUnits);
@@ -183,7 +183,7 @@ export class TokenWrapper extends ContractWrapper {
      * @return Transaction hash.
      */
     public async transferAsync(tokenAddress: string, fromAddress: string, toAddress: string,
-                               amountInBaseUnits: BigNumber.BigNumber): Promise<string> {
+                               amountInBaseUnits: BigNumber): Promise<string> {
         assert.isETHAddressHex('tokenAddress', tokenAddress);
         await assert.isSenderAddressAsync('fromAddress', fromAddress, this._web3Wrapper);
         assert.isETHAddressHex('toAddress', toAddress);
@@ -215,7 +215,7 @@ export class TokenWrapper extends ContractWrapper {
      * @return Transaction hash.
      */
     public async transferFromAsync(tokenAddress: string, fromAddress: string, toAddress: string,
-                                   senderAddress: string, amountInBaseUnits: BigNumber.BigNumber):
+                                   senderAddress: string, amountInBaseUnits: BigNumber):
                                    Promise<string> {
         assert.isETHAddressHex('tokenAddress', tokenAddress);
         assert.isETHAddressHex('fromAddress', fromAddress);

--- a/src/globals.d.ts
+++ b/src/globals.d.ts
@@ -12,12 +12,6 @@ declare module 'web3-provider-engine/subproviders/rpc';
 // disallow `namespace`, we disable tslint for the following.
 /* tslint:disable */
 declare namespace Chai {
-    interface NumberComparer {
-        (value: number|BigNumber.BigNumber, message?: string): Assertion;
-    }
-    interface NumericComparison {
-        greaterThan: NumberComparer;
-    }
     interface Assertion {
         bignumber: Assertion;
         // HACK: In order to comply with chai-as-promised we make eventually a `PromisedAssertion` not an `Assertion`
@@ -70,8 +64,6 @@ declare module 'truffle-hdwallet-provider' {
 
 // abi-decoder declarations
 interface DecodedLogArg {
-    name: string;
-    value: string|BigNumber.BigNumber;
 }
 interface DecodedLog {
     name: string;

--- a/src/globalsAugment.d.ts
+++ b/src/globalsAugment.d.ts
@@ -1,0 +1,18 @@
+import BigNumber from 'bignumber.js';
+
+declare global {
+    /* tslint:disable */
+    namespace Chai {
+        interface NumberComparer {
+            (value: number|BigNumber, message?: string): Assertion;
+        }
+        interface NumericComparison {
+            greaterThan: NumberComparer;
+        }
+    }
+    /* tslint:enable */
+    interface DecodedLogArg {
+        name: string;
+        value: string|BigNumber;
+    }
+}

--- a/src/globalsAugment.d.ts
+++ b/src/globalsAugment.d.ts
@@ -1,6 +1,11 @@
 import BigNumber from 'bignumber.js';
 
+// HACK: This module overrides the Chai namespace so that we can use BigNumber types inside.
+// Source: https://github.com/Microsoft/TypeScript/issues/7352#issuecomment-191547232
 declare global {
+    // HACK: In order to merge the bignumber declaration added by chai-bignumber to the chai Assertion
+    // interface we must use `namespace` as the Chai definitelyTyped definition does. Since we otherwise
+    // disallow `namespace`, we disable tslint for the following.
     /* tslint:disable */
     namespace Chai {
         interface NumberComparer {

--- a/src/types.ts
+++ b/src/types.ts
@@ -1,4 +1,5 @@
 import * as Web3 from 'web3';
+import BigNumber from 'bignumber.js';
 
 export enum ZeroExError {
     ContractDoesNotExist = 'CONTRACT_DOES_NOT_EXIST',
@@ -33,8 +34,8 @@ export interface ECSignature {
 
 export type OrderAddresses = [string, string, string, string, string];
 
-export type OrderValues = [BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber,
-                           BigNumber.BigNumber, BigNumber.BigNumber, BigNumber.BigNumber];
+export type OrderValues = [BigNumber, BigNumber, BigNumber,
+                           BigNumber, BigNumber, BigNumber];
 
 export interface LogEvent<ArgsType> extends LogWithDecodedArgs<ArgsType> {
     removed: boolean;
@@ -54,77 +55,77 @@ export interface ExchangeContract extends Web3.ContractInstance {
         callAsync: () => Promise<string>;
     };
     getUnavailableTakerTokenAmount: {
-        callAsync: (orderHash: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber.BigNumber>;
+        callAsync: (orderHash: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber>;
     };
     isRoundingError: {
-        callAsync: (takerTokenFillAmount: BigNumber.BigNumber, takerTokenAmount: BigNumber.BigNumber,
-                    makerTokenAmount: BigNumber.BigNumber, txOpts?: TxOpts) => Promise<boolean>;
+        callAsync: (takerTokenFillAmount: BigNumber, takerTokenAmount: BigNumber,
+                    makerTokenAmount: BigNumber, txOpts?: TxOpts) => Promise<boolean>;
     };
     fillOrder: {
         sendTransactionAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues,
-                               fillTakerTokenAmount: BigNumber.BigNumber,
+                               fillTakerTokenAmount: BigNumber,
                                shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                                v: number, r: string, s: string, txOpts?: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues,
-                           fillTakerTokenAmount: BigNumber.BigNumber,
+                           fillTakerTokenAmount: BigNumber,
                            shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                            v: number, r: string, s: string, txOpts?: TxOpts) => Promise<number>;
     };
     batchFillOrders: {
         sendTransactionAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                               fillTakerTokenAmounts: BigNumber.BigNumber[],
+                               fillTakerTokenAmounts: BigNumber[],
                                shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                                v: number[], r: string[], s: string[], txOpts?: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                           fillTakerTokenAmounts: BigNumber.BigNumber[],
+                           fillTakerTokenAmounts: BigNumber[],
                            shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                            v: number[], r: string[], s: string[], txOpts?: TxOpts) => Promise<number>;
     };
     fillOrdersUpTo: {
         sendTransactionAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                               fillTakerTokenAmount: BigNumber.BigNumber,
+                               fillTakerTokenAmount: BigNumber,
                                shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                                v: number[], r: string[], s: string[], txOpts?: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                           fillTakerTokenAmount: BigNumber.BigNumber,
+                           fillTakerTokenAmount: BigNumber,
                            shouldThrowOnInsufficientBalanceOrAllowance: boolean,
                            v: number[], r: string[], s: string[], txOpts?: TxOpts) => Promise<number>;
     };
     cancelOrder: {
         sendTransactionAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues,
-                               cancelTakerTokenAmount: BigNumber.BigNumber, txOpts?: TxOpts) => Promise<string>;
+                               cancelTakerTokenAmount: BigNumber, txOpts?: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues,
-                           cancelTakerTokenAmount: BigNumber.BigNumber,
+                           cancelTakerTokenAmount: BigNumber,
                            txOpts?: TxOpts) => Promise<number>;
     };
     batchCancelOrders: {
         sendTransactionAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                               cancelTakerTokenAmounts: BigNumber.BigNumber[], txOpts?: TxOpts) => Promise<string>;
+                               cancelTakerTokenAmounts: BigNumber[], txOpts?: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                           cancelTakerTokenAmounts: BigNumber.BigNumber[],
+                           cancelTakerTokenAmounts: BigNumber[],
                            txOpts?: TxOpts) => Promise<number>;
     };
     fillOrKillOrder: {
         sendTransactionAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues,
-                               fillTakerTokenAmount: BigNumber.BigNumber,
+                               fillTakerTokenAmount: BigNumber,
                                v: number, r: string, s: string, txOpts?: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues,
-                           fillTakerTokenAmount: BigNumber.BigNumber,
+                           fillTakerTokenAmount: BigNumber,
                            v: number, r: string, s: string, txOpts?: TxOpts) => Promise<number>;
     };
     batchFillOrKillOrders: {
         sendTransactionAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                               fillTakerTokenAmounts: BigNumber.BigNumber[],
+                               fillTakerTokenAmounts: BigNumber[],
                                v: number[], r: string[], s: string[], txOpts: TxOpts) => Promise<string>;
         estimateGasAsync: (orderAddresses: OrderAddresses[], orderValues: OrderValues[],
-                           fillTakerTokenAmounts: BigNumber.BigNumber[],
+                           fillTakerTokenAmounts: BigNumber[],
                            v: number[], r: string[], s: string[], txOpts?: TxOpts) => Promise<number>;
     };
     filled: {
-        callAsync: (orderHash: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber.BigNumber>;
+        callAsync: (orderHash: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber>;
     };
     cancelled: {
-        callAsync: (orderHash: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber.BigNumber>;
+        callAsync: (orderHash: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber>;
     };
     getOrderHash: {
         callAsync: (orderAddresses: OrderAddresses, orderValues: OrderValues) => Promise<string>;
@@ -133,22 +134,22 @@ export interface ExchangeContract extends Web3.ContractInstance {
 
 export interface TokenContract extends Web3.ContractInstance {
     balanceOf: {
-        callAsync: (address: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber.BigNumber>;
+        callAsync: (address: string, defaultBlock?: Web3.BlockParam) => Promise<BigNumber>;
     };
     allowance: {
         callAsync: (ownerAddress: string, allowedAddress: string,
-                    defaultBlock?: Web3.BlockParam) => Promise<BigNumber.BigNumber>;
+                    defaultBlock?: Web3.BlockParam) => Promise<BigNumber>;
     };
     transfer: {
-        sendTransactionAsync: (toAddress: string, amountInBaseUnits: BigNumber.BigNumber,
+        sendTransactionAsync: (toAddress: string, amountInBaseUnits: BigNumber,
                                txOpts?: TxOpts) => Promise<string>;
     };
     transferFrom: {
-        sendTransactionAsync: (fromAddress: string, toAddress: string, amountInBaseUnits: BigNumber.BigNumber,
+        sendTransactionAsync: (fromAddress: string, toAddress: string, amountInBaseUnits: BigNumber,
                                txOpts?: TxOpts) => Promise<string>;
     };
     approve: {
-        sendTransactionAsync: (proxyAddress: string, amountInBaseUnits: BigNumber.BigNumber,
+        sendTransactionAsync: (proxyAddress: string, amountInBaseUnits: BigNumber,
                                txOpts?: TxOpts) => Promise<string>;
     };
 }
@@ -179,7 +180,7 @@ export interface EtherTokenContract extends Web3.ContractInstance {
         sendTransactionAsync: (txOpts: TxOpts) => Promise<string>;
     };
     withdraw: {
-        sendTransactionAsync: (amount: BigNumber.BigNumber, txOpts: TxOpts) => Promise<string>;
+        sendTransactionAsync: (amount: BigNumber, txOpts: TxOpts) => Promise<string>;
     };
 }
 
@@ -253,10 +254,10 @@ export interface LogFillContractEventArgs {
     feeRecipient: string;
     makerToken: string;
     takerToken: string;
-    filledMakerTokenAmount: BigNumber.BigNumber;
-    filledTakerTokenAmount: BigNumber.BigNumber;
-    paidMakerFee: BigNumber.BigNumber;
-    paidTakerFee: BigNumber.BigNumber;
+    filledMakerTokenAmount: BigNumber;
+    filledTakerTokenAmount: BigNumber;
+    paidMakerFee: BigNumber;
+    paidTakerFee: BigNumber;
     tokens: string;
     orderHash: string;
 }
@@ -265,43 +266,43 @@ export interface LogCancelContractEventArgs {
     feeRecipient: string;
     makerToken: string;
     takerToken: string;
-    cancelledMakerTokenAmount: BigNumber.BigNumber;
-    cancelledTakerTokenAmount: BigNumber.BigNumber;
+    cancelledMakerTokenAmount: BigNumber;
+    cancelledTakerTokenAmount: BigNumber;
     tokens: string;
     orderHash: string;
 }
 export interface LogErrorContractEventArgs {
-    errorId: BigNumber.BigNumber;
+    errorId: BigNumber;
     orderHash: string;
 }
 export type ExchangeContractEventArgs = LogFillContractEventArgs|LogCancelContractEventArgs|LogErrorContractEventArgs;
 export interface TransferContractEventArgs {
     _from: string;
     _to: string;
-    _value: BigNumber.BigNumber;
+    _value: BigNumber;
 }
 export interface ApprovalContractEventArgs {
     _owner: string;
     _spender: string;
-    _value: BigNumber.BigNumber;
+    _value: BigNumber;
 }
 export type TokenContractEventArgs = TransferContractEventArgs|ApprovalContractEventArgs;
 export type ContractEventArgs = ExchangeContractEventArgs|TokenContractEventArgs;
-export type ContractEventArg = string|BigNumber.BigNumber;
+export type ContractEventArg = string|BigNumber;
 
 export interface Order {
     maker: string;
     taker: string;
-    makerFee: BigNumber.BigNumber;
-    takerFee: BigNumber.BigNumber;
-    makerTokenAmount: BigNumber.BigNumber;
-    takerTokenAmount: BigNumber.BigNumber;
+    makerFee: BigNumber;
+    takerFee: BigNumber;
+    makerTokenAmount: BigNumber;
+    takerTokenAmount: BigNumber;
     makerTokenAddress: string;
     takerTokenAddress: string;
-    salt: BigNumber.BigNumber;
+    salt: BigNumber;
     exchangeContractAddress: string;
     feeRecipient: string;
-    expirationUnixTimestampSec: BigNumber.BigNumber;
+    expirationUnixTimestampSec: BigNumber;
 }
 
 export interface SignedOrder extends Order {
@@ -309,7 +310,7 @@ export interface SignedOrder extends Order {
 }
 
 //                          [address, name, symbol, decimals, ipfsHash, swarmHash]
-export type TokenMetadata = [string, string, string, BigNumber.BigNumber, string, string];
+export type TokenMetadata = [string, string, string, BigNumber, string, string];
 
 export interface Token {
     name: string;
@@ -321,7 +322,7 @@ export interface Token {
 export interface TxOpts {
     from: string;
     gas?: number;
-    value?: BigNumber.BigNumber;
+    value?: BigNumber;
 }
 
 export interface TokenAddressBySymbol {
@@ -362,12 +363,12 @@ export type DoneCallback = (err?: Error) => void;
 
 export interface OrderCancellationRequest {
     order: Order|SignedOrder;
-    takerTokenCancelAmount: BigNumber.BigNumber;
+    takerTokenCancelAmount: BigNumber;
 }
 
 export interface OrderFillRequest {
     signedOrder: SignedOrder;
-    takerTokenFillAmount: BigNumber.BigNumber;
+    takerTokenFillAmount: BigNumber;
 }
 
 export type AsyncMethod = (...args: any[]) => Promise<any>;
@@ -395,7 +396,7 @@ export interface JSONRPCPayload {
  * etherTokenContractAddress: The address of an ether token contract to use
  */
 export interface ZeroExConfig {
-    gasPrice?: BigNumber.BigNumber; // Gas price to use with every transaction
+    gasPrice?: BigNumber; // Gas price to use with every transaction
     exchangeContractAddress?: string;
     tokenRegistryContractAddress?: string;
     etherTokenContractAddress?: string;
@@ -439,7 +440,7 @@ export interface Artifact {
  * allowance/balance to fill the entire remaining order amount.
  */
 export interface ValidateOrderFillableOpts {
-    expectedFillTakerTokenAmount?: BigNumber.BigNumber;
+    expectedFillTakerTokenAmount?: BigNumber;
 }
 
 /*

--- a/src/utils/abi_decoder.ts
+++ b/src/utils/abi_decoder.ts
@@ -1,6 +1,6 @@
 import * as Web3 from 'web3';
 import * as _ from 'lodash';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {AbiType, DecodedLogArgs, LogWithDecodedArgs, RawLog, SolidityTypes, ContractEventArgs} from '../types';
 import * as SolidityCoder from 'web3/lib/solidity/coder';
 

--- a/src/utils/assert.ts
+++ b/src/utils/assert.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import * as Web3 from 'web3';
 import {Web3Wrapper} from '../web3_wrapper';
 import {SchemaValidator, Schema} from '0x-json-schemas';
@@ -7,8 +7,8 @@ import {SchemaValidator, Schema} from '0x-json-schemas';
 const HEX_REGEX = /^0x[0-9A-F]*$/i;
 
 export const assert = {
-    isBigNumber(variableName: string, value: BigNumber.BigNumber): void {
-        const isBigNumber = _.isObject(value) && value.isBigNumber;
+    isBigNumber(variableName: string, value: BigNumber): void {
+        const isBigNumber = _.isObject(value) && (value as any).isBigNumber;
         this.assert(isBigNumber, this.typeAssertionMessage(variableName, 'BigNumber', value));
     },
     isUndefined(value: any, variableName?: string): void {

--- a/src/utils/constants.ts
+++ b/src/utils/constants.ts
@@ -1,4 +1,4 @@
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 
 export const constants = {
     NULL_ADDRESS: '0x0000000000000000000000000000000000000000',

--- a/src/utils/order_validation_utils.ts
+++ b/src/utils/order_validation_utils.ts
@@ -1,4 +1,5 @@
 import * as _ from 'lodash';
+import BigNumber from 'bignumber.js';
 import {ExchangeContractErrs, SignedOrder, Order, ZeroExError, TradeSide, TransferType} from '../types';
 import {ZeroEx} from '../0x';
 import {TokenWrapper} from '../contract_wrappers/token_wrapper';
@@ -16,7 +17,7 @@ export class OrderValidationUtils {
     }
     public async validateOrderFillableOrThrowAsync(
         exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder, zrxTokenAddress: string,
-        expectedFillTakerTokenAmount?: BigNumber.BigNumber): Promise<void> {
+        expectedFillTakerTokenAmount?: BigNumber): Promise<void> {
         const orderHash = utils.getOrderHashHex(signedOrder);
         const unavailableTakerTokenAmount = await this.exchangeWrapper.getUnavailableTakerAmountAsync(orderHash);
         this.validateRemainingFillAmountNotZeroOrThrow(
@@ -48,8 +49,8 @@ export class OrderValidationUtils {
     }
     public async validateFillOrderThrowIfInvalidAsync(
         exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder,
-        fillTakerTokenAmount: BigNumber.BigNumber, takerAddress: string,
-        zrxTokenAddress: string): Promise<BigNumber.BigNumber> {
+        fillTakerTokenAmount: BigNumber, takerAddress: string,
+        zrxTokenAddress: string): Promise<BigNumber> {
         if (fillTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderFillAmountZero);
         }
@@ -83,7 +84,7 @@ export class OrderValidationUtils {
     }
     public async validateFillOrKillOrderThrowIfInvalidAsync(
         exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder,
-        fillTakerTokenAmount: BigNumber.BigNumber, takerAddress: string, zrxTokenAddress: string): Promise<void> {
+        fillTakerTokenAmount: BigNumber, takerAddress: string, zrxTokenAddress: string): Promise<void> {
         const filledTakerTokenAmount = await this.validateFillOrderThrowIfInvalidAsync(
             exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress,
         );
@@ -92,8 +93,8 @@ export class OrderValidationUtils {
         }
     }
     public async validateCancelOrderThrowIfInvalidAsync(order: Order,
-                                                        cancelTakerTokenAmount: BigNumber.BigNumber,
-                                                        unavailableTakerTokenAmount: BigNumber.BigNumber,
+                                                        cancelTakerTokenAmount: BigNumber,
+                                                        unavailableTakerTokenAmount: BigNumber,
     ): Promise<void> {
         if (cancelTakerTokenAmount.eq(0)) {
             throw new Error(ExchangeContractErrs.OrderCancelAmountZero);
@@ -108,7 +109,7 @@ export class OrderValidationUtils {
     }
     public async validateFillOrderBalancesAllowancesThrowIfInvalidAsync(
         exchangeTradeEmulator: ExchangeTransferSimulator, signedOrder: SignedOrder,
-        fillTakerTokenAmount: BigNumber.BigNumber, senderAddress: string, zrxTokenAddress: string): Promise<void> {
+        fillTakerTokenAmount: BigNumber, senderAddress: string, zrxTokenAddress: string): Promise<void> {
         const fillMakerTokenAmount = this.getPartialAmount(
             fillTakerTokenAmount,
             signedOrder.takerTokenAmount,
@@ -142,20 +143,20 @@ export class OrderValidationUtils {
         );
     }
     private validateRemainingFillAmountNotZeroOrThrow(
-        takerTokenAmount: BigNumber.BigNumber, unavailableTakerTokenAmount: BigNumber.BigNumber,
+        takerTokenAmount: BigNumber, unavailableTakerTokenAmount: BigNumber,
     ) {
         if (takerTokenAmount.eq(unavailableTakerTokenAmount)) {
             throw new Error(ExchangeContractErrs.OrderRemainingFillAmountZero);
         }
     }
-    private validateOrderNotExpiredOrThrow(expirationUnixTimestampSec: BigNumber.BigNumber) {
+    private validateOrderNotExpiredOrThrow(expirationUnixTimestampSec: BigNumber) {
         const currentUnixTimestampSec = utils.getCurrentUnixTimestamp();
         if (expirationUnixTimestampSec.lessThan(currentUnixTimestampSec)) {
             throw new Error(ExchangeContractErrs.OrderFillExpired);
         }
     }
-    private getPartialAmount(numerator: BigNumber.BigNumber, denominator: BigNumber.BigNumber,
-                             target: BigNumber.BigNumber): BigNumber.BigNumber {
+    private getPartialAmount(numerator: BigNumber, denominator: BigNumber,
+                             target: BigNumber): BigNumber {
         const fillMakerTokenAmount = numerator
                                      .mul(target)
                                      .div(denominator)

--- a/src/utils/utils.ts
+++ b/src/utils/utils.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as ethABI from 'ethereumjs-abi';
 import * as ethUtil from 'ethereumjs-util';
 import {Order, SignedOrder, SolidityTypes} from '../types';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import BN = require('bn.js');
 
 export const utils = {
@@ -12,7 +12,7 @@ export const utils = {
      * expects values of Solidity type `uint` to be passed as type `BN`.
      * We do not use BN anywhere else in the codebase.
      */
-    bigNumberToBN(value: BigNumber.BigNumber) {
+    bigNumberToBN(value: BigNumber) {
         return new BN(value.toString(), 10);
     },
     consoleLog(message: string): void {
@@ -49,7 +49,7 @@ export const utils = {
         const hashHex = ethUtil.bufferToHex(hashBuff);
         return hashHex;
     },
-    getCurrentUnixTimestamp(): BigNumber.BigNumber {
+    getCurrentUnixTimestamp(): BigNumber {
         return new BigNumber(Date.now() / 1000);
     },
 };

--- a/src/web3_wrapper.ts
+++ b/src/web3_wrapper.ts
@@ -1,6 +1,6 @@
 import * as _ from 'lodash';
 import * as Web3 from 'web3';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');
 import {ZeroExError, Artifact} from './types';
 import {Contract} from './contract';
@@ -75,11 +75,11 @@ export class Web3Wrapper {
         );
         return contractInstance;
     }
-    public toWei(ethAmount: BigNumber.BigNumber): BigNumber.BigNumber {
+    public toWei(ethAmount: BigNumber): BigNumber {
         const balanceWei = this.web3.toWei(ethAmount, 'ether');
         return balanceWei;
     }
-    public async getBalanceInWeiAsync(owner: string): Promise<BigNumber.BigNumber> {
+    public async getBalanceInWeiAsync(owner: string): Promise<BigNumber> {
         let balanceInWei = await promisify(this.web3.eth.getBalance)(owner);
         balanceInWei = new BigNumber(balanceInWei);
         return balanceInWei;

--- a/test/0x.js_test.ts
+++ b/test/0x.js_test.ts
@@ -2,7 +2,7 @@ import * as _ from 'lodash';
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';
 import 'mocha';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import * as Sinon from 'sinon';
 import {ZeroEx, Order, ZeroExError, LogWithDecodedArgs, ApprovalContractEventArgs, TokenEvents} from '../src';
 import {constants} from './utils/constants';

--- a/test/ether_token_wrapper_test.ts
+++ b/test/ether_token_wrapper_test.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';
 import * as Web3 from 'web3';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {web3Factory} from './utils/web3_factory';
 import {ZeroEx, ZeroExError} from '../src';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
@@ -23,7 +23,7 @@ describe('EtherTokenWrapper', () => {
     let userAddresses: string[];
     let addressWithETH: string;
     let wethContractAddress: string;
-    let depositWeiAmount: BigNumber.BigNumber;
+    let depositWeiAmount: BigNumber;
     let decimalPlaces: number;
     const gasPrice = new BigNumber(1);
     const zeroExConfig = {

--- a/test/exchange_transfer_simulator_test.ts
+++ b/test/exchange_transfer_simulator_test.ts
@@ -1,5 +1,5 @@
 import * as chai from 'chai';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {chaiSetup} from './utils/chai_setup';
 import {web3Factory} from './utils/web3_factory';
 import {ZeroEx, ExchangeContractErrs, Token} from '../src';

--- a/test/exchange_wrapper_test.ts
+++ b/test/exchange_wrapper_test.ts
@@ -1,7 +1,7 @@
 import 'mocha';
 import * as chai from 'chai';
 import * as Web3 from 'web3';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {chaiSetup} from './utils/chai_setup';
 import {web3Factory} from './utils/web3_factory';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
@@ -545,8 +545,8 @@ describe('ExchangeWrapper', () => {
         let makerTokenAddress: string;
         let takerTokenAddress: string;
         let takerAddress: string;
-        let fillableAmount: BigNumber.BigNumber;
-        let partialFillAmount: BigNumber.BigNumber;
+        let fillableAmount: BigNumber;
+        let partialFillAmount: BigNumber;
         let signedOrder: SignedOrder;
         let orderHash: string;
         before(() => {
@@ -621,7 +621,7 @@ describe('ExchangeWrapper', () => {
         let coinbase: string;
         let takerAddress: string;
         let makerAddress: string;
-        let fillableAmount: BigNumber.BigNumber;
+        let fillableAmount: BigNumber;
         let signedOrder: SignedOrder;
         const takerTokenFillAmountInBaseUnits = new BigNumber(1);
         const cancelTakerAmountInBaseUnits = new BigNumber(1);

--- a/test/order_validation_test.ts
+++ b/test/order_validation_test.ts
@@ -1,6 +1,6 @@
 import * as chai from 'chai';
 import * as Web3 from 'web3';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import * as Sinon from 'sinon';
 import {chaiSetup} from './utils/chai_setup';
 import {web3Factory} from './utils/web3_factory';
@@ -211,8 +211,8 @@ describe('OrderValidation', () => {
     describe('#validateFillOrderBalancesAllowancesThrowIfInvalidAsync', () => {
         let exchangeTransferSimulator: ExchangeTransferSimulator;
         let transferFromAsync: Sinon.SinonSpy;
-        const bigNumberMatch = (expected: BigNumber.BigNumber) => {
-            return Sinon.match((value: BigNumber.BigNumber) => value.eq(expected));
+        const bigNumberMatch = (expected: BigNumber) => {
+            return Sinon.match((value: BigNumber) => value.eq(expected));
         };
         beforeEach('create exchangeTransferSimulator', async () => {
             exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token);

--- a/test/token_wrapper_test.ts
+++ b/test/token_wrapper_test.ts
@@ -2,7 +2,7 @@ import 'mocha';
 import * as chai from 'chai';
 import {chaiSetup} from './utils/chai_setup';
 import * as Web3 from 'web3';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import promisify = require('es6-promisify');
 import {web3Factory} from './utils/web3_factory';
 import {
@@ -51,7 +51,7 @@ describe('TokenWrapper', () => {
     });
     describe('#transferAsync', () => {
         let token: Token;
-        let transferAmount: BigNumber.BigNumber;
+        let transferAmount: BigNumber;
         before(() => {
             token = tokens[0];
             transferAmount = new BigNumber(42);

--- a/test/utils/fill_scenarios.ts
+++ b/test/utils/fill_scenarios.ts
@@ -1,4 +1,4 @@
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {ZeroEx, Token, SignedOrder} from '../../src';
 import {orderFactory} from '../utils/order_factory';
 import {constants} from './constants';
@@ -21,8 +21,8 @@ export class FillScenarios {
     }
     public async createFillableSignedOrderAsync(makerTokenAddress: string, takerTokenAddress: string,
                                                 makerAddress: string, takerAddress: string,
-                                                fillableAmount: BigNumber.BigNumber,
-                                                expirationUnixTimestampSec?: BigNumber.BigNumber):
+                                                fillableAmount: BigNumber,
+                                                expirationUnixTimestampSec?: BigNumber):
                                            Promise<SignedOrder> {
         return this.createAsymmetricFillableSignedOrderAsync(
             makerTokenAddress, takerTokenAddress, makerAddress, takerAddress,
@@ -31,10 +31,10 @@ export class FillScenarios {
     }
     public async createFillableSignedOrderWithFeesAsync(
         makerTokenAddress: string, takerTokenAddress: string,
-        makerFee: BigNumber.BigNumber, takerFee: BigNumber.BigNumber,
+        makerFee: BigNumber, takerFee: BigNumber,
         makerAddress: string, takerAddress: string,
-        fillableAmount: BigNumber.BigNumber,
-        feeRecepient: string, expirationUnixTimestampSec?: BigNumber.BigNumber,
+        fillableAmount: BigNumber,
+        feeRecepient: string, expirationUnixTimestampSec?: BigNumber,
     ): Promise<SignedOrder> {
         return this.createAsymmetricFillableSignedOrderWithFeesAsync(
             makerTokenAddress, takerTokenAddress, makerFee, takerFee, makerAddress, takerAddress,
@@ -43,8 +43,8 @@ export class FillScenarios {
     }
     public async createAsymmetricFillableSignedOrderAsync(
         makerTokenAddress: string, takerTokenAddress: string, makerAddress: string, takerAddress: string,
-        makerFillableAmount: BigNumber.BigNumber, takerFillableAmount: BigNumber.BigNumber,
-        expirationUnixTimestampSec?: BigNumber.BigNumber): Promise<SignedOrder> {
+        makerFillableAmount: BigNumber, takerFillableAmount: BigNumber,
+        expirationUnixTimestampSec?: BigNumber): Promise<SignedOrder> {
         const makerFee = new BigNumber(0);
         const takerFee = new BigNumber(0);
         const feeRecepient = constants.NULL_ADDRESS;
@@ -54,8 +54,8 @@ export class FillScenarios {
         );
     }
     public async createPartiallyFilledSignedOrderAsync(makerTokenAddress: string, takerTokenAddress: string,
-                                                       takerAddress: string, fillableAmount: BigNumber.BigNumber,
-                                                       partialFillAmount: BigNumber.BigNumber) {
+                                                       takerAddress: string, fillableAmount: BigNumber,
+                                                       partialFillAmount: BigNumber) {
         const [makerAddress] = this.userAddresses;
         const signedOrder = await this.createAsymmetricFillableSignedOrderAsync(
             makerTokenAddress, takerTokenAddress, makerAddress, takerAddress,
@@ -69,10 +69,10 @@ export class FillScenarios {
     }
     private async createAsymmetricFillableSignedOrderWithFeesAsync(
         makerTokenAddress: string, takerTokenAddress: string,
-        makerFee: BigNumber.BigNumber, takerFee: BigNumber.BigNumber,
+        makerFee: BigNumber, takerFee: BigNumber,
         makerAddress: string, takerAddress: string,
-        makerFillableAmount: BigNumber.BigNumber, takerFillableAmount: BigNumber.BigNumber,
-        feeRecepient: string, expirationUnixTimestampSec?: BigNumber.BigNumber): Promise<SignedOrder> {
+        makerFillableAmount: BigNumber, takerFillableAmount: BigNumber,
+        feeRecepient: string, expirationUnixTimestampSec?: BigNumber): Promise<SignedOrder> {
 
         await Promise.all([
             this.increaseBalanceAndAllowanceAsync(makerTokenAddress, makerAddress, makerFillableAmount),
@@ -90,7 +90,7 @@ export class FillScenarios {
         return signedOrder;
     }
     private async increaseBalanceAndAllowanceAsync(
-        tokenAddress: string, address: string, amount: BigNumber.BigNumber): Promise<void> {
+        tokenAddress: string, address: string, amount: BigNumber): Promise<void> {
         if (amount.isZero() || address === ZeroEx.NULL_ADDRESS) {
             return; // noop
         }
@@ -100,11 +100,11 @@ export class FillScenarios {
         ]);
     }
     private async increaseBalanceAsync(
-        tokenAddress: string, address: string, amount: BigNumber.BigNumber): Promise<void> {
+        tokenAddress: string, address: string, amount: BigNumber): Promise<void> {
         await this.zeroEx.token.transferAsync(tokenAddress, this.coinbase, address, amount);
     }
     private async increaseAllowanceAsync(
-        tokenAddress: string, address: string, amount: BigNumber.BigNumber): Promise<void> {
+        tokenAddress: string, address: string, amount: BigNumber): Promise<void> {
         const oldMakerAllowance = await this.zeroEx.token.getProxyAllowanceAsync(tokenAddress, address);
         const newMakerAllowance = oldMakerAllowance.plus(amount);
         await this.zeroEx.token.setProxyAllowanceAsync(

--- a/test/utils/order_factory.ts
+++ b/test/utils/order_factory.ts
@@ -1,5 +1,5 @@
 import * as _ from 'lodash';
-import * as BigNumber from 'bignumber.js';
+import BigNumber from 'bignumber.js';
 import {ZeroEx, SignedOrder} from '../../src';
 
 export const orderFactory = {
@@ -7,15 +7,15 @@ export const orderFactory = {
         zeroEx: ZeroEx,
         maker: string,
         taker: string,
-        makerFee: BigNumber.BigNumber,
-        takerFee: BigNumber.BigNumber,
-        makerTokenAmount: BigNumber.BigNumber,
+        makerFee: BigNumber,
+        takerFee: BigNumber,
+        makerTokenAmount: BigNumber,
         makerTokenAddress: string,
-        takerTokenAmount: BigNumber.BigNumber,
+        takerTokenAmount: BigNumber,
         takerTokenAddress: string,
         exchangeContractAddress: string,
         feeRecipient: string,
-        expirationUnixTimestampSec?: BigNumber.BigNumber): Promise<SignedOrder> {
+        expirationUnixTimestampSec?: BigNumber): Promise<SignedOrder> {
         const defaultExpirationUnixTimestampSec = new BigNumber(2524604400); // Close to infinite
         expirationUnixTimestampSec = _.isUndefined(expirationUnixTimestampSec) ?
             defaultExpirationUnixTimestampSec :

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,23 +8,19 @@
   dependencies:
     jsonschema "^1.2.0"
 
-"@types/bignumber.js@^4.0.2":
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/@types/bignumber.js/-/bignumber.js-4.0.2.tgz#22a16946c9faa9f2c9c0ad4c7c3734a3033320ae"
-
-"@types/fs-extra@^4.0.0":
+"@types/fs-extra@4.0.0":
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
   dependencies:
     "@types/node" "*"
 
-"@types/handlebars@^4.0.31":
-  version "4.0.33"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.33.tgz#ee45696b067e4bdf15c3956710a4c36c17d8f8f0"
+"@types/handlebars@4.0.31":
+  version "4.0.31"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.31.tgz#a7fba66fafe42713aee88eeca8db91192efe6e72"
 
-"@types/highlight.js@^9.1.8":
-  version "9.1.9"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.9.tgz#ed6336955eaf233b75eb7923b9b1f373d045ef01"
+"@types/highlight.js@9.1.8":
+  version "9.1.8"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.8.tgz#d227f18bcb8f3f187e16965f2444859a04689758"
 
 "@types/jsonschema@^1.1.1":
   version "1.1.1"
@@ -32,15 +28,19 @@
   dependencies:
     jsonschema "*"
 
-"@types/lodash@^4.14.37", "@types/lodash@^4.14.64":
+"@types/lodash@4.14.74":
+  version "4.14.74"
+  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
+
+"@types/lodash@^4.14.64":
   version "4.14.68"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.68.tgz#754fbab68bd2bbb69547dc8ce7574f7012eed7f6"
 
-"@types/marked@0.0.28":
-  version "0.0.28"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.0.28.tgz#44ba754e9fa51432583e8eb30a7c4dd249b52faa"
+"@types/marked@0.3.0":
+  version "0.3.0"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
 
-"@types/minimatch@^2.0.29":
+"@types/minimatch@2.0.29":
   version "2.0.29"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
 
@@ -52,9 +52,9 @@
   version "8.0.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.9.tgz#19f44c3b6cb8a70d261d366f73650e3e3891ab2d"
 
-"@types/shelljs@^0.7.0":
-  version "0.7.2"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.2.tgz#c2bdb3fe80cd7a3da08750ca898ae44c589671f3"
+"@types/shelljs@0.7.0":
+  version "0.7.0"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.0.tgz#229c157c6bc1e67d6b990e6c5e18dbd2ff58cff0"
   dependencies:
     "@types/node" "*"
 
@@ -752,9 +752,9 @@ big.js@^3.1.3:
   version "3.1.3"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.1.3.tgz#4cada2193652eb3ca9ec8e55c9015669c9806978"
 
-bignumber.js@^4.0.2:
-  version "4.0.2"
-  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.0.2.tgz#2d1dc37ee5968867ecea90b6da4d16e68608d21d"
+bignumber.js@^4.0.2, bignumber.js@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-4.1.0.tgz#db6f14067c140bd46624815a7916c92d9b6c24b1"
 
 "bignumber.js@git+https://github.com/debris/bignumber.js#master":
   version "2.0.7"
@@ -4728,17 +4728,17 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
-typedoc@^0.8.0:
-  version "0.8.0"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.8.0.tgz#d7172bc6a29964f451b7609c005beadadefe2361"
+typedoc@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.9.0.tgz#159bff7c7784ce5b91d86f3e4cc8928e62040957"
   dependencies:
-    "@types/fs-extra" "^4.0.0"
-    "@types/handlebars" "^4.0.31"
-    "@types/highlight.js" "^9.1.8"
-    "@types/lodash" "^4.14.37"
-    "@types/marked" "0.0.28"
-    "@types/minimatch" "^2.0.29"
-    "@types/shelljs" "^0.7.0"
+    "@types/fs-extra" "4.0.0"
+    "@types/handlebars" "4.0.31"
+    "@types/highlight.js" "9.1.8"
+    "@types/lodash" "4.14.74"
+    "@types/marked" "0.3.0"
+    "@types/minimatch" "2.0.29"
+    "@types/shelljs" "0.7.0"
     fs-extra "^4.0.0"
     handlebars "^4.0.6"
     highlight.js "^9.0.0"

--- a/yarn.lock
+++ b/yarn.lock
@@ -8,19 +8,26 @@
   dependencies:
     jsonschema "^1.2.0"
 
-"@types/fs-extra@4.0.0":
-  version "4.0.0"
-  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.0.tgz#1dd742ad5c9bce308f7a52d02ebc01421bc9102f"
+"@types/fs-extra@^4.0.0":
+  version "4.0.3"
+  resolved "https://registry.yarnpkg.com/@types/fs-extra/-/fs-extra-4.0.3.tgz#87343b1ab99415b61817ac894ed622355a0ebf67"
   dependencies:
     "@types/node" "*"
 
-"@types/handlebars@4.0.31":
-  version "4.0.31"
-  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.31.tgz#a7fba66fafe42713aee88eeca8db91192efe6e72"
+"@types/glob@*":
+  version "5.0.33"
+  resolved "https://registry.yarnpkg.com/@types/glob/-/glob-5.0.33.tgz#3dff7c6ce09d65abe919c7961dc3dee016f36ad7"
+  dependencies:
+    "@types/minimatch" "*"
+    "@types/node" "*"
 
-"@types/highlight.js@9.1.8":
-  version "9.1.8"
-  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.8.tgz#d227f18bcb8f3f187e16965f2444859a04689758"
+"@types/handlebars@^4.0.31":
+  version "4.0.36"
+  resolved "https://registry.yarnpkg.com/@types/handlebars/-/handlebars-4.0.36.tgz#ff57c77fa1ab6713bb446534ddc4d979707a3a79"
+
+"@types/highlight.js@^9.1.8":
+  version "9.1.10"
+  resolved "https://registry.yarnpkg.com/@types/highlight.js/-/highlight.js-9.1.10.tgz#b621f809cd9573b80992b90cffc5788208e3069c"
 
 "@types/jsonschema@^1.1.1":
   version "1.1.1"
@@ -28,19 +35,15 @@
   dependencies:
     jsonschema "*"
 
-"@types/lodash@4.14.74":
-  version "4.14.74"
-  resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.74.tgz#ac3bd8db988e7f7038e5d22bd76a7ba13f876168"
-
-"@types/lodash@^4.14.64":
+"@types/lodash@^4.14.37", "@types/lodash@^4.14.64":
   version "4.14.68"
   resolved "https://registry.yarnpkg.com/@types/lodash/-/lodash-4.14.68.tgz#754fbab68bd2bbb69547dc8ce7574f7012eed7f6"
 
-"@types/marked@0.3.0":
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.3.0.tgz#583c223dd33385a1dda01aaf77b0cd0411c4b524"
+"@types/marked@0.0.28":
+  version "0.0.28"
+  resolved "https://registry.yarnpkg.com/@types/marked/-/marked-0.0.28.tgz#44ba754e9fa51432583e8eb30a7c4dd249b52faa"
 
-"@types/minimatch@2.0.29":
+"@types/minimatch@*", "@types/minimatch@^2.0.29":
   version "2.0.29"
   resolved "https://registry.yarnpkg.com/@types/minimatch/-/minimatch-2.0.29.tgz#5002e14f75e2d71e564281df0431c8c1b4a2a36a"
 
@@ -52,10 +55,11 @@
   version "8.0.9"
   resolved "https://registry.yarnpkg.com/@types/node/-/node-8.0.9.tgz#19f44c3b6cb8a70d261d366f73650e3e3891ab2d"
 
-"@types/shelljs@0.7.0":
-  version "0.7.0"
-  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.0.tgz#229c157c6bc1e67d6b990e6c5e18dbd2ff58cff0"
+"@types/shelljs@^0.7.0":
+  version "0.7.5"
+  resolved "https://registry.yarnpkg.com/@types/shelljs/-/shelljs-0.7.5.tgz#5834fb7385d1137bd2be5842f2c278ac36a117f4"
   dependencies:
+    "@types/glob" "*"
     "@types/node" "*"
 
 "@types/sinon@^2.2.2":
@@ -4728,17 +4732,17 @@ typedoc-default-themes@^0.5.0:
   version "0.5.0"
   resolved "https://registry.yarnpkg.com/typedoc-default-themes/-/typedoc-default-themes-0.5.0.tgz#6dc2433e78ed8bea8e887a3acde2f31785bd6227"
 
-typedoc@^0.9.0:
-  version "0.9.0"
-  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.9.0.tgz#159bff7c7784ce5b91d86f3e4cc8928e62040957"
+typedoc@~0.8.0:
+  version "0.8.0"
+  resolved "https://registry.yarnpkg.com/typedoc/-/typedoc-0.8.0.tgz#d7172bc6a29964f451b7609c005beadadefe2361"
   dependencies:
-    "@types/fs-extra" "4.0.0"
-    "@types/handlebars" "4.0.31"
-    "@types/highlight.js" "9.1.8"
-    "@types/lodash" "4.14.74"
-    "@types/marked" "0.3.0"
-    "@types/minimatch" "2.0.29"
-    "@types/shelljs" "0.7.0"
+    "@types/fs-extra" "^4.0.0"
+    "@types/handlebars" "^4.0.31"
+    "@types/highlight.js" "^9.1.8"
+    "@types/lodash" "^4.14.37"
+    "@types/marked" "0.0.28"
+    "@types/minimatch" "^2.0.29"
+    "@types/shelljs" "^0.7.0"
     fs-extra "^4.0.0"
     handlebars "^4.0.6"
     highlight.js "^9.0.0"


### PR DESCRIPTION
This PR:
* Uses the new version of BigNumber that contains native types
* This allows us to write types as `BigNumber` instead of `BigNumber.BigNumber`
* This forces us to use a hack with chai namespace
