### PR TITLE
Allow timeout for await transaction mined

### DIFF
--- a/src/0x.ts
+++ b/src/0x.ts
@@ -303,7 +303,7 @@ export class ZeroEx {
             (resolve: (receipt: TransactionReceiptWithDecodedLogs) => void, reject) => {
             const intervalId = intervalUtils.setAsyncExcludingInterval(async () => {
                 if (timeoutExceeded) {
-                    clearInterval(intervalId);
+                    intervalUtils.clearAsyncExcludingInterval(intervalId);
                     return reject(ZeroExError.TransactionMiningTimeout);
                 }
 

--- a/src/types.ts
+++ b/src/types.ts
@@ -16,6 +16,7 @@ export enum ZeroExError {
     OutOfGas = 'OUT_OF_GAS',
     NoNetworkId = 'NO_NETWORK_ID',
     SubscriptionNotFound = 'SUBSCRIPTION_NOT_FOUND',
+    TransactionMiningTimeout = 'TRANSACTION_MINING_TIMEOUT',
 }
 
 export enum InternalZeroExError {


### PR DESCRIPTION
This PR:
* Currently awaitTransactionMinedAsync will poll forever
* Allow an optional 'timeoutMs' argument which will reject the promise after n ms
