### PR TITLE
Clean up subscription state.

### DIFF
--- a/src/contract_wrappers/contract_wrapper.ts
+++ b/src/contract_wrappers/contract_wrapper.ts
@@ -38,19 +38,10 @@ export class ContractWrapper {
         this._onLogAddedSubscriptionToken = undefined;
         this._onLogRemovedSubscriptionToken = undefined;
     }
-    protected _subscribe<ArgsType extends ContractEventArgs>(
-        address: string, eventName: ContractEvents, indexFilterValues: IndexedFilterValues, abi: Web3.ContractAbi,
-        callback: EventCallback<ArgsType>): string {
-        const filter = filterUtils.getFilter(address, eventName, indexFilterValues, abi);
-        if (_.isUndefined(this._blockAndLogStreamer)) {
-            this._startBlockAndLogStream();
-        }
-        const filterToken = filterUtils.generateUUID();
-        this._filters[filterToken] = filter;
-        this._filterCallbacks[filterToken] = callback;
-        return filterToken;
-    }
-    protected unsubscribeAll(): void {
+    /**
+     * Cancels all existing subscriptions
+     */
+    public unsubscribeAll(): void {
         const filterTokens = _.keys(this._filterCallbacks);
         _.each(filterTokens, filterToken => {
             this._unsubscribe(filterToken);
@@ -69,6 +60,18 @@ export class ContractWrapper {
         if (_.isEmpty(this._filters)) {
             this._stopBlockAndLogStream();
         }
+    }
+    protected _subscribe<ArgsType extends ContractEventArgs>(
+        address: string, eventName: ContractEvents, indexFilterValues: IndexedFilterValues, abi: Web3.ContractAbi,
+        callback: EventCallback<ArgsType>): string {
+        const filter = filterUtils.getFilter(address, eventName, indexFilterValues, abi);
+        if (_.isUndefined(this._blockAndLogStreamer)) {
+            this._startBlockAndLogStream();
+        }
+        const filterToken = filterUtils.generateUUID();
+        this._filters[filterToken] = filter;
+        this._filterCallbacks[filterToken] = callback;
+        return filterToken;
     }
     protected async _getLogsAsync<ArgsType extends ContractEventArgs>(
         address: string, eventName: ContractEvents, subscriptionOpts: SubscriptionOpts,

--- a/src/contract_wrappers/contract_wrapper.ts
+++ b/src/contract_wrappers/contract_wrapper.ts
@@ -50,6 +50,12 @@ export class ContractWrapper {
         this._filterCallbacks[filterToken] = callback;
         return filterToken;
     }
+    protected unsubscribeAll(): void {
+        const filterTokens = _.keys(this._filterCallbacks);
+        _.each(filterTokens, filterToken => {
+            this._unsubscribe(filterToken);
+        });
+    }
     protected _unsubscribe(filterToken: string, err?: Error): void {
         if (_.isUndefined(this._filters[filterToken])) {
             throw new Error(ZeroExError.SubscriptionNotFound);

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -49,7 +49,6 @@ const SHOULD_VALIDATE_BY_DEFAULT = true;
  */
 export class ExchangeWrapper extends ContractWrapper {
     private _exchangeContractIfExists?: ExchangeContract;
-    private _activeSubscriptions: string[];
     private _orderValidationUtils: OrderValidationUtils;
     private _tokenWrapper: TokenWrapper;
     private _exchangeContractErrCodesToMsg = {
@@ -84,7 +83,6 @@ export class ExchangeWrapper extends ContractWrapper {
         super(web3Wrapper, abiDecoder);
         this._tokenWrapper = tokenWrapper;
         this._orderValidationUtils = new OrderValidationUtils(tokenWrapper, this);
-        this._activeSubscriptions = [];
         this._contractAddressIfExists = contractAddressIfExists;
     }
     /**
@@ -666,7 +664,6 @@ export class ExchangeWrapper extends ContractWrapper {
         const subscriptionToken = this._subscribe<ArgsType>(
             exchangeContractAddress, eventName, indexFilterValues, artifacts.ExchangeArtifact.abi, callback,
         );
-        this._activeSubscriptions.push(subscriptionToken);
         return subscriptionToken;
     }
     /**
@@ -674,8 +671,13 @@ export class ExchangeWrapper extends ContractWrapper {
      * @param   subscriptionToken Subscription token returned by `subscribe()`
      */
     public unsubscribe(subscriptionToken: string): void {
-        _.pull(this._activeSubscriptions, subscriptionToken);
         this._unsubscribe(subscriptionToken);
+    }
+    /**
+     * Cancels all existing subscriptions
+     */
+    public unsubscribeAll(): void {
+        super.unsubscribeAll();
     }
     /**
      * Gets historical logs without creating a subscription
@@ -825,13 +827,7 @@ export class ExchangeWrapper extends ContractWrapper {
         const ZRXtokenAddress = await exchangeInstance.ZRX_TOKEN_CONTRACT.callAsync();
         return ZRXtokenAddress;
     }
-    /**
-     * Cancels all existing subscriptions
-     */
-    public unsubscribeAll(): void {
-        _.forEach(this._activeSubscriptions, this._unsubscribe.bind(this));
-        this._activeSubscriptions = [];
-    }
+
     private async _invalidateContractInstancesAsync(): Promise<void> {
         this.unsubscribeAll();
         delete this._exchangeContractIfExists;

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -674,12 +674,6 @@ export class ExchangeWrapper extends ContractWrapper {
         this._unsubscribe(subscriptionToken);
     }
     /**
-     * Cancels all existing subscriptions
-     */
-    public unsubscribeAll(): void {
-        super.unsubscribeAll();
-    }
-    /**
      * Gets historical logs without creating a subscription
      * @param   eventName           The exchange contract event you would like to subscribe to.
      * @param   subscriptionOpts    Subscriptions options that let you configure the subscription.

--- a/src/contract_wrappers/exchange_wrapper.ts
+++ b/src/contract_wrappers/exchange_wrapper.ts
@@ -827,7 +827,6 @@ export class ExchangeWrapper extends ContractWrapper {
         const ZRXtokenAddress = await exchangeInstance.ZRX_TOKEN_CONTRACT.callAsync();
         return ZRXtokenAddress;
     }
-
     private async _invalidateContractInstancesAsync(): Promise<void> {
         this.unsubscribeAll();
         delete this._exchangeContractIfExists;

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -29,13 +29,11 @@ const ALLOWANCE_TO_ZERO_GAS_AMOUNT = 47275;
 export class TokenWrapper extends ContractWrapper {
     public UNLIMITED_ALLOWANCE_IN_BASE_UNITS = constants.UNLIMITED_ALLOWANCE_IN_BASE_UNITS;
     private _tokenContractsByAddress: {[address: string]: TokenContract};
-    private _activeSubscriptions: string[];
     private _tokenTransferProxyContractAddressFetcher: () => Promise<string>;
     constructor(web3Wrapper: Web3Wrapper, abiDecoder: AbiDecoder,
                 tokenTransferProxyContractAddressFetcher: () => Promise<string>) {
         super(web3Wrapper, abiDecoder);
         this._tokenContractsByAddress = {};
-        this._activeSubscriptions = [];
         this._tokenTransferProxyContractAddressFetcher = tokenTransferProxyContractAddressFetcher;
     }
     /**
@@ -262,7 +260,6 @@ export class TokenWrapper extends ContractWrapper {
         const subscriptionToken = this._subscribe<ArgsType>(
             tokenAddress, eventName, indexFilterValues, artifacts.TokenArtifact.abi, callback,
         );
-        this._activeSubscriptions.push(subscriptionToken);
         return subscriptionToken;
     }
     /**
@@ -270,7 +267,6 @@ export class TokenWrapper extends ContractWrapper {
      * @param   subscriptionToken Subscription token returned by `subscribe()`
      */
     public unsubscribe(subscriptionToken: string): void {
-        _.pull(this._activeSubscriptions, subscriptionToken);
         this._unsubscribe(subscriptionToken);
     }
     /**
@@ -298,8 +294,7 @@ export class TokenWrapper extends ContractWrapper {
      * Cancels all existing subscriptions
      */
     public unsubscribeAll(): void {
-        _.forEach(this._activeSubscriptions, this._unsubscribe.bind(this));
-        this._activeSubscriptions = [];
+        super.unsubscribeAll();
     }
     private _invalidateContractInstancesAsync(): void {
         this.unsubscribeAll();

--- a/src/contract_wrappers/token_wrapper.ts
+++ b/src/contract_wrappers/token_wrapper.ts
@@ -290,12 +290,6 @@ export class TokenWrapper extends ContractWrapper {
         );
         return logs;
     }
-    /**
-     * Cancels all existing subscriptions
-     */
-    public unsubscribeAll(): void {
-        super.unsubscribeAll();
-    }
     private _invalidateContractInstancesAsync(): void {
         this.unsubscribeAll();
         this._tokenContractsByAddress = {};

--- a/test/subscription_test.ts
+++ b/test/subscription_test.ts
@@ -11,13 +11,8 @@ import {
     ZeroEx,
     ZeroExError,
     Token,
-    SubscriptionOpts,
-    TokenEvents,
-    ContractEvent,
-    TransferContractEventArgs,
     ApprovalContractEventArgs,
-    TokenContractEventArgs,
-    LogWithDecodedArgs,
+    TokenEvents,
     LogEvent,
 } from '../src';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
@@ -51,7 +46,6 @@ describe('SubscriptionTest', () => {
     afterEach(async () => {
         await blockchainLifecycle.revertAsync();
     });
-
     describe('#subscribe', () => {
         const indexFilterValues = {};
         const shouldThrowOnInsufficientBalanceOrAllowance = true;
@@ -72,6 +66,7 @@ describe('SubscriptionTest', () => {
             (async () => {
                 const callback = (err: Error, logEvent: LogEvent<ApprovalContractEventArgs>) => {
                     expect(err).to.not.be.undefined();
+                    expect(err).to.not.be.null();
                     expect(logEvent).to.be.undefined();
                     done();
                 };
@@ -89,7 +84,6 @@ describe('SubscriptionTest', () => {
                 const callback = (err: Error, logEvent: LogEvent<ApprovalContractEventArgs>) => { };
                 zeroEx.token.subscribe(
                     tokenAddress, TokenEvents.Approval, indexFilterValues, callback);
-                await zeroEx.token.setAllowanceAsync(tokenAddress, coinbase, addressWithoutFunds, allowanceAmount);
                 stubs = [
                   Sinon.stub((zeroEx as any)._web3Wrapper, 'getBlockAsync')
                    .throws("JSON RPC error")

--- a/test/subscription_test.ts
+++ b/test/subscription_test.ts
@@ -65,7 +65,6 @@ describe('SubscriptionTest', () => {
         it('Should receive the Error when an error occurs', (done: DoneCallback) => {
             (async () => {
                 const callback = (err: Error, logEvent: LogEvent<ApprovalContractEventArgs>) => {
-                    expect(err).to.not.be.undefined();
                     expect(err).to.not.be.null();
                     expect(logEvent).to.be.undefined();
                     done();

--- a/test/subscription_test.ts
+++ b/test/subscription_test.ts
@@ -1,0 +1,93 @@
+import 'mocha';
+import * as chai from 'chai';
+import * as Sinon from 'sinon';
+import {chaiSetup} from './utils/chai_setup';
+import * as Web3 from 'web3';
+import BigNumber from 'bignumber.js';
+import promisify = require('es6-promisify');
+import {web3Factory} from './utils/web3_factory';
+import {
+    ZeroEx,
+    ZeroExError,
+    Token,
+    SubscriptionOpts,
+    TokenEvents,
+    ContractEvent,
+    TransferContractEventArgs,
+    ApprovalContractEventArgs,
+    TokenContractEventArgs,
+    LogWithDecodedArgs,
+    LogEvent,
+} from '../src';
+import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
+import {TokenUtils} from './utils/token_utils';
+import {DoneCallback, BlockParamLiteral} from '../src/types';
+
+chaiSetup.configure();
+const expect = chai.expect;
+const blockchainLifecycle = new BlockchainLifecycle();
+
+describe('SubscriptionTest', () => {
+    let web3: Web3;
+    let zeroEx: ZeroEx;
+    let userAddresses: string[];
+    let tokens: Token[];
+    let tokenUtils: TokenUtils;
+    let coinbase: string;
+    let addressWithoutFunds: string;
+    before(async () => {
+        web3 = web3Factory.create();
+        zeroEx = new ZeroEx(web3.currentProvider);
+        userAddresses = await zeroEx.getAvailableAddressesAsync();
+        tokens = await zeroEx.tokenRegistry.getTokensAsync();
+        tokenUtils = new TokenUtils(tokens);
+        coinbase = userAddresses[0];
+        addressWithoutFunds = userAddresses[1];
+    });
+    beforeEach(async () => {
+        await blockchainLifecycle.startAsync();
+    });
+    afterEach(async () => {
+        await blockchainLifecycle.revertAsync();
+    });
+
+    describe('#subscribe', () => {
+        const indexFilterValues = {};
+        const shouldThrowOnInsufficientBalanceOrAllowance = true;
+        let tokenAddress: string;
+        const transferAmount = new BigNumber(42);
+        const allowanceAmount = new BigNumber(42);
+        before(() => {
+            const token = tokens[0];
+            tokenAddress = token.address;
+        });
+        afterEach(() => {
+            zeroEx.token.unsubscribeAll();
+        });
+        it('Should receive the Error when an error occurs', (done: DoneCallback) => {
+            (async () => {
+                const callback = (err: Error, logEvent: LogEvent<ApprovalContractEventArgs>) => {
+                    expect(err).to.not.be.undefined();
+                    expect(logEvent).to.be.undefined();
+                    done();
+                };
+                Sinon.stub((zeroEx as any)._web3Wrapper, 'getBlockAsync')
+                 .throws("JSON RPC error")
+                zeroEx.token.subscribe(
+                    tokenAddress, TokenEvents.Approval, indexFilterValues, callback);
+                await zeroEx.token.setAllowanceAsync(tokenAddress, coinbase, addressWithoutFunds, allowanceAmount);
+            })().catch(done);
+         });
+        it('Should allow unsubscribeAll to be called multiple times', (done: DoneCallback) => {
+            (async () => {
+                const callback = (err: Error, logEvent: LogEvent<ApprovalContractEventArgs>) => { };
+                zeroEx.token.subscribe(
+                    tokenAddress, TokenEvents.Approval, indexFilterValues, callback);
+                await zeroEx.token.setAllowanceAsync(tokenAddress, coinbase, addressWithoutFunds, allowanceAmount);
+                zeroEx.token.unsubscribeAll();
+                zeroEx.token.unsubscribeAll();
+                done();
+            })().catch(done);
+         });
+    })
+  })


### PR DESCRIPTION
This PR:

Higher level classes which implemented `activeSubscriptions` could result in mismatched state from the base.

In the case of an exception, keep the state correct between contract wrapper, exchange wrapper and token wrapper.