### PR TITLE
Calculate the remaining order amount in maker units

### DIFF
--- a/src/types.ts
+++ b/src/types.ts
@@ -493,6 +493,7 @@ export interface OrderRelevantState {
     makerFeeProxyAllowance: BigNumber;
     filledTakerTokenAmount: BigNumber;
     canceledTakerTokenAmount: BigNumber;
+    remainingFillableMakerTokenAmount: BigNumber;
 }
 
 export interface OrderStateValid {

--- a/src/utils/order_state_utils.ts
+++ b/src/utils/order_state_utils.ts
@@ -65,7 +65,7 @@ export class OrderStateUtils {
         const totalMakerTokenAmount = signedOrder.makerTokenAmount;
         const totalTakerTokenAmount = signedOrder.takerTokenAmount;
         const remainingTakerTokenAmount = totalTakerTokenAmount.minus(unavailableTakerTokenAmount);
-        // 200 in order, 100 unavailable  = 100 remaning, 0.5 remaning proportion
+        // 200 in order, 100 unavailable  = 100 remaning, 0.5 remaining in taker proportion
         const remainingTakerProportion = remainingTakerTokenAmount.dividedBy(totalTakerTokenAmount);
         const remainingMakerTokenAmount = remainingTakerProportion.times(totalMakerTokenAmount);
         // min allowance, balance in account of maker

--- a/src/utils/order_state_utils.ts
+++ b/src/utils/order_state_utils.ts
@@ -72,9 +72,7 @@ export class OrderStateUtils {
         const fillableMakerTokenAmount = BigNumber.min([makerProxyAllowance, makerBalance]);
         // min ^, remaining order maker token amount
         const remainingFillableMakerTokenAmount = BigNumber.min(fillableMakerTokenAmount, remainingMakerTokenAmount);
-        // TODO
         // edge case when maker token is ZRX
-        // rounding issues, check if its fillabae
         const orderRelevantState = {
             makerBalance,
             makerProxyAllowance,

--- a/src/utils/order_state_utils.ts
+++ b/src/utils/order_state_utils.ts
@@ -65,12 +65,9 @@ export class OrderStateUtils {
         const totalMakerTokenAmount = signedOrder.makerTokenAmount;
         const totalTakerTokenAmount = signedOrder.takerTokenAmount;
         const remainingTakerTokenAmount = totalTakerTokenAmount.minus(unavailableTakerTokenAmount);
-        // 200 in order, 100 unavailable  = 100 remaning, 0.5 remaining in taker proportion
         const remainingMakerTokenAmount = remainingTakerTokenAmount.times(totalMakerTokenAmount)
                                                                    .dividedToIntegerBy(totalTakerTokenAmount);
-        // min allowance, balance in account of maker
         const fillableMakerTokenAmount = BigNumber.min([makerProxyAllowance, makerBalance]);
-        // min ^, remaining order maker token amount
         const remainingFillableMakerTokenAmount = BigNumber.min(fillableMakerTokenAmount, remainingMakerTokenAmount);
         // TODO: Handle edge case where maker token is ZRX with fee
         const orderRelevantState = {

--- a/src/utils/order_state_utils.ts
+++ b/src/utils/order_state_utils.ts
@@ -66,13 +66,13 @@ export class OrderStateUtils {
         const totalTakerTokenAmount = signedOrder.takerTokenAmount;
         const remainingTakerTokenAmount = totalTakerTokenAmount.minus(unavailableTakerTokenAmount);
         // 200 in order, 100 unavailable  = 100 remaning, 0.5 remaining in taker proportion
-        const remainingTakerProportion = remainingTakerTokenAmount.dividedBy(totalTakerTokenAmount);
-        const remainingMakerTokenAmount = remainingTakerProportion.times(totalMakerTokenAmount);
+        const remainingMakerTokenAmount = remainingTakerTokenAmount.times(totalMakerTokenAmount)
+                                                                   .dividedToIntegerBy(totalTakerTokenAmount);
         // min allowance, balance in account of maker
         const fillableMakerTokenAmount = BigNumber.min([makerProxyAllowance, makerBalance]);
         // min ^, remaining order maker token amount
         const remainingFillableMakerTokenAmount = BigNumber.min(fillableMakerTokenAmount, remainingMakerTokenAmount);
-        // edge case when maker token is ZRX
+        // TODO: Handle edge case where maker token is ZRX with fee
         const orderRelevantState = {
             makerBalance,
             makerProxyAllowance,

--- a/test/order_state_watcher_test.ts
+++ b/test/order_state_watcher_test.ts
@@ -190,7 +190,8 @@ describe('OrderStateWatcher', () => {
                     const orderRelevantState = validOrderState.orderRelevantState;
                     const remainingMakerBalance = makerBalance.sub(fillAmountInBaseUnits);
                     const remainingFillable = fillableAmount.minus(fillAmountInBaseUnits);
-                    expect(remainingFillable).to.be.bignumber.equal(fillableAmount.minus(fillAmountInBaseUnits));
+                    expect(orderRelevantState.remainingFillableMakerTokenAmount).to.be.bignumber.equal(
+                        remainingFillable);
                     expect(orderRelevantState.makerBalance).to.be.bignumber.equal(remainingMakerBalance);
                     if (eventCount === 2) {
                         done();
@@ -204,7 +205,7 @@ describe('OrderStateWatcher', () => {
             })().catch(done);
         });
         describe('remainingFillableMakerTokenAmount', () => {
-          it('should calculate correct reamining fillable', (done: DoneCallback) => {
+          it('should calculate correct remaining fillable', (done: DoneCallback) => {
               (async () => {
                   const takerFillableAmount = new BigNumber(10);
                   const makerFillableAmount = new BigNumber(20);
@@ -265,20 +266,20 @@ describe('OrderStateWatcher', () => {
 
                   const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
 
-                  const transferAmount = new BigNumber(1);
+                  const remainingAmount = new BigNumber(1);
+                  const transferAmount = makerBalance.sub(remainingAmount);
                   zeroEx.orderStateWatcher.addOrder(signedOrder);
 
                   const callback = reportCallbackErrors(done)((orderState: OrderState) => {
                       const validOrderState = orderState as OrderStateValid;
                       const orderRelevantState = validOrderState.orderRelevantState;
-
                       expect(orderRelevantState.remainingFillableMakerTokenAmount).to.be.bignumber.equal(
-                          transferAmount);
+                          remainingAmount);
                       done();
                   });
                   zeroEx.orderStateWatcher.subscribe(callback);
-                  await zeroEx.token.transferAsync(makerToken.address, maker, ZeroEx.NULL_ADDRESS,
-                                                   makerBalance.minus(transferAmount));
+                  await zeroEx.token.transferAsync(
+                      makerToken.address, maker, ZeroEx.NULL_ADDRESS, transferAmount);
               })().catch(done);
           });
         });

--- a/test/order_state_watcher_test.ts
+++ b/test/order_state_watcher_test.ts
@@ -189,6 +189,8 @@ describe('OrderStateWatcher', () => {
                     expect(validOrderState.orderHash).to.be.equal(orderHash);
                     const orderRelevantState = validOrderState.orderRelevantState;
                     const remainingMakerBalance = makerBalance.sub(fillAmountInBaseUnits);
+                    const remainingFillable = fillableAmount.minus(fillAmountInBaseUnits);
+                    expect(remainingFillable).to.be.bignumber.equal(fillableAmount.minus(fillAmountInBaseUnits));
                     expect(orderRelevantState.makerBalance).to.be.bignumber.equal(remainingMakerBalance);
                     if (eventCount === 2) {
                         done();

--- a/test/order_state_watcher_test.ts
+++ b/test/order_state_watcher_test.ts
@@ -204,7 +204,7 @@ describe('OrderStateWatcher', () => {
             })().catch(done);
         });
         describe('remainingFillableMakerTokenAmount', () => {
-          it.only('should calculate correct reamining fillable', (done: DoneCallback) => {
+          it('should calculate correct reamining fillable', (done: DoneCallback) => {
               (async () => {
                   const takerFillableAmount = new BigNumber(10);
                   const makerFillableAmount = new BigNumber(20);
@@ -235,7 +235,7 @@ describe('OrderStateWatcher', () => {
                   );
               })().catch(done);
           });
-          it.only('should emit approved amount when approved amount is lower', (done: DoneCallback) => {
+          it('should emit approved amount when approved amount is lower', (done: DoneCallback) => {
               (async () => {
                   signedOrder = await fillScenarios.createFillableSignedOrderAsync(
                       makerToken.address, takerToken.address, maker, taker, fillableAmount,
@@ -257,7 +257,7 @@ describe('OrderStateWatcher', () => {
                   await zeroEx.token.setProxyAllowanceAsync(makerToken.address, maker, changedMakerApprovalAmount);
               })().catch(done);
           });
-          it.only('should emit balance amount when balance amount is lower', (done: DoneCallback) => {
+          it('should emit balance amount when balance amount is lower', (done: DoneCallback) => {
               (async () => {
                   signedOrder = await fillScenarios.createFillableSignedOrderAsync(
                       makerToken.address, takerToken.address, maker, taker, fillableAmount,

--- a/test/order_state_watcher_test.ts
+++ b/test/order_state_watcher_test.ts
@@ -235,7 +235,7 @@ describe('OrderStateWatcher', () => {
                   );
               })().catch(done);
           });
-          it('should emit approved amount when approved amount is lower', (done: DoneCallback) => {
+          it('should equal approved amount when approved amount is lowest', (done: DoneCallback) => {
               (async () => {
                   signedOrder = await fillScenarios.createFillableSignedOrderAsync(
                       makerToken.address, takerToken.address, maker, taker, fillableAmount,
@@ -257,7 +257,7 @@ describe('OrderStateWatcher', () => {
                   await zeroEx.token.setProxyAllowanceAsync(makerToken.address, maker, changedMakerApprovalAmount);
               })().catch(done);
           });
-          it('should emit balance amount when balance amount is lower', (done: DoneCallback) => {
+          it('should equal balance amount when balance amount is lowest', (done: DoneCallback) => {
               (async () => {
                   signedOrder = await fillScenarios.createFillableSignedOrderAsync(
                       makerToken.address, takerToken.address, maker, taker, fillableAmount,


### PR DESCRIPTION
Calculate the remaining maker token amount that is fillable.

```
remainingTaker = totalTakerAmount - unavailableTakerAmount
remainingProportion = remainingTaker / totalTakerAmount

makerFillable = min(allowance, balance)
makerOrderRemaining = totalMakerAmount * remainingProportion
orderMakerFillable = min(makerFillable, makerOrderRemaining)
```

TODO 
- [x] basic test (symmetric)
- [x] where maker token and taker token are different, with different amounts (asymmetric)
- [x] discuss the naming
- [x] when allowance and balance are lower than remaining order amount