### PR TITLE
Calculate remaining proportions from fee to ratio proportions

### DIFF
--- a/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
+++ b/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
@@ -38,8 +38,8 @@ export class RemainingFillableCalculator {
     }
     private hasSufficientFundsForFeeAndTransferAmount(): boolean {
         if (this._isMakerTokenZRX) {
-            const totalZRXTransferAmount = this._remainingMakerTokenAmount.plus(this._remainingMakerFeeAmount);
-            return this._transferrableMakerTokenAmount.gte(totalZRXTransferAmount);
+            const totalZRXTransferAmountRequired = this._remainingMakerTokenAmount.plus(this._remainingMakerFeeAmount);
+            return this._transferrableMakerTokenAmount.gte(totalZRXTransferAmountRequired);
         } else {
             const hasSufficientFundsForTransferAmount = this._transferrableMakerTokenAmount.gte(
                                                             this._remainingMakerTokenAmount);

--- a/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
+++ b/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
@@ -74,8 +74,12 @@ export class RemainingFillableCalculator {
         }
         // When Ratio is not fully divisible there can be remainders which cannot be represented, so they are floored.
         // This can result in a RoundingError being thrown by the Exchange Contract.
-        const partiallyFillableMakerTokenAmount = fillableTimesInMakerTokenUnits.times(orderToFeeRatio).floor();
-        const partiallyFillableFeeTokenAmount = fillableTimesInFeeTokenBaseUnits.times(orderToFeeRatio).floor();
+        const partiallyFillableMakerTokenAmount = fillableTimesInMakerTokenUnits
+                                                     .times(this.signedOrder.makerTokenAmount)
+                                                     .dividedToIntegerBy(this.signedOrder.makerFee);
+        const partiallyFillableFeeTokenAmount = fillableTimesInFeeTokenBaseUnits
+                                                     .times(this.signedOrder.makerTokenAmount)
+                                                     .dividedToIntegerBy(this.signedOrder.makerFee);
         const partiallyFillableAmount = BigNumber.min(partiallyFillableMakerTokenAmount,
                                                       partiallyFillableFeeTokenAmount);
         return partiallyFillableAmount;

--- a/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
+++ b/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
@@ -1,71 +1,83 @@
-import {
-    SignedOrder,
-} from '../types';
-import { BigNumber } from 'bignumber.js';
+import {SignedOrder} from '../types';
+import {BigNumber} from 'bignumber.js';
+
 export class RemainingFillableCalculator {
-    private _signedOrder: SignedOrder;
-    private _isMakerTokenZRX: boolean;
-    private _transferrableMakerTokenAmount: BigNumber;
-    private _transferrableMakerFeeTokenAmount: BigNumber;
-    private _remainingMakerTokenAmount: BigNumber;
-    private _remainingMakerFeeAmount: BigNumber;
+    private signedOrder: SignedOrder;
+    private isMakerTokenZRX: boolean;
+    // Transferrable Amount is the minimum of Approval and Balance
+    private transferrableMakerTokenAmount: BigNumber;
+    private transferrableMakerFeeTokenAmount: BigNumber;
+    private remainingMakerTokenAmount: BigNumber;
+    private remainingMakerFeeAmount: BigNumber;
     constructor(signedOrder: SignedOrder,
                 isMakerTokenZRX: boolean,
                 transferrableMakerTokenAmount: BigNumber,
                 transferrableMakerFeeTokenAmount: BigNumber,
                 remainingMakerTokenAmount: BigNumber) {
-        this._signedOrder = signedOrder;
-        this._isMakerTokenZRX = isMakerTokenZRX;
-        this._transferrableMakerTokenAmount = transferrableMakerTokenAmount;
-        this._transferrableMakerFeeTokenAmount = transferrableMakerFeeTokenAmount;
-        this._remainingMakerTokenAmount = remainingMakerTokenAmount;
-        this._remainingMakerFeeAmount = remainingMakerTokenAmount.times(signedOrder.makerFee)
-                                                                 .dividedToIntegerBy(signedOrder.makerTokenAmount);
+        this.signedOrder = signedOrder;
+        this.isMakerTokenZRX = isMakerTokenZRX;
+        this.transferrableMakerTokenAmount = transferrableMakerTokenAmount;
+        this.transferrableMakerFeeTokenAmount = transferrableMakerFeeTokenAmount;
+        this.remainingMakerTokenAmount = remainingMakerTokenAmount;
+        this.remainingMakerFeeAmount = remainingMakerTokenAmount.times(signedOrder.makerFee)
+                                                                .dividedToIntegerBy(signedOrder.makerTokenAmount);
     }
     public computeRemainingMakerFillable(): BigNumber {
         if (this.hasSufficientFundsForFeeAndTransferAmount()) {
-            return this._remainingMakerTokenAmount;
+            return this.remainingMakerTokenAmount;
         }
-        if (this._signedOrder.makerFee.isZero()) {
-            return BigNumber.min(this._remainingMakerTokenAmount, this._transferrableMakerTokenAmount);
-        } else {
-            return this.calculatePartiallyFillableMakerTokenAmount();
+        if (this.signedOrder.makerFee.isZero()) {
+            return BigNumber.min(this.remainingMakerTokenAmount, this.transferrableMakerTokenAmount);
         }
+        return this.calculatePartiallyFillableMakerTokenAmount();
     }
     public computeRemainingTakerFillable(): BigNumber {
-        return this.computeRemainingMakerFillable().times(this._signedOrder.takerTokenAmount)
-                                                   .dividedToIntegerBy(this._signedOrder.makerTokenAmount);
+        return this.computeRemainingMakerFillable().times(this.signedOrder.takerTokenAmount)
+                                                   .dividedToIntegerBy(this.signedOrder.makerTokenAmount);
     }
     private hasSufficientFundsForFeeAndTransferAmount(): boolean {
-        if (this._isMakerTokenZRX) {
-            const totalZRXTransferAmountRequired = this._remainingMakerTokenAmount.plus(this._remainingMakerFeeAmount);
-            return this._transferrableMakerTokenAmount.gte(totalZRXTransferAmountRequired);
+        if (this.isMakerTokenZRX) {
+            const totalZRXTransferAmountRequired = this.remainingMakerTokenAmount.plus(this.remainingMakerFeeAmount);
+            const hasSufficientFunds = this.transferrableMakerTokenAmount.greaterThanOrEqualTo(
+                                                                            totalZRXTransferAmountRequired);
+            return hasSufficientFunds;
         } else {
-            const hasSufficientFundsForTransferAmount = this._transferrableMakerTokenAmount.gte(
-                                                            this._remainingMakerTokenAmount);
-            const hasSufficientFundsForFeeAmount = this._transferrableMakerFeeTokenAmount.gte(
-                                                       this._remainingMakerFeeAmount);
-            return (hasSufficientFundsForTransferAmount && hasSufficientFundsForFeeAmount);
+            const hasSufficientFundsForTransferAmount = this.transferrableMakerTokenAmount.greaterThanOrEqualTo(
+                                                            this.remainingMakerTokenAmount);
+            const hasSufficientFundsForFeeAmount = this.transferrableMakerFeeTokenAmount.greaterThanOrEqualTo(
+                                                       this.remainingMakerFeeAmount);
+            const hasSufficientFunds = hasSufficientFundsForTransferAmount && hasSufficientFundsForFeeAmount;
+            return hasSufficientFunds;
         }
     }
-
     private calculatePartiallyFillableMakerTokenAmount(): BigNumber {
-        const orderToFeeRatio = this._signedOrder.makerTokenAmount.dividedToIntegerBy(this._signedOrder.makerFee);
+        // The number of times the maker can fill the order, if each fill only required the transfer of a single
+        // baseUnit of fee tokens.
+        // Given an order for 200 wei for 2 ZRXwei fee, find 100 wei for 1 ZRXwei. Order ratio is then 100:1
+        const orderToFeeRatio = this.signedOrder.makerTokenAmount.dividedBy(this.signedOrder.makerFee);
         // Maximum number of times the Maker can fill the order, given the fees
-        const fillableTimesInFeeTokenUnits = BigNumber.min(this._transferrableMakerFeeTokenAmount,
-                                                           this._remainingMakerFeeAmount);
+        // Given 2 ZRXwei, the maximum amount of times Maker can fill this order, in terms of fees, is 2
+        const fillableTimesInFeeTokenBaseUnits = BigNumber.min(this.transferrableMakerFeeTokenAmount,
+                                                               this.remainingMakerFeeAmount);
         // Maximum number of times the Maker can fill the order, given the Maker Token Balance
-        let fillableTimesInMakerTokenUnits = this._transferrableMakerTokenAmount.dividedToIntegerBy(orderToFeeRatio);
-        if (this._isMakerTokenZRX) {
-            const totalZRXTokenPooled = this._transferrableMakerTokenAmount;
+        // Assuming a balance of 150 wei, maker can fill this order 1 time.
+        let fillableTimesInMakerTokenUnits = this.transferrableMakerTokenAmount.dividedBy(orderToFeeRatio);
+        if (this.isMakerTokenZRX) {
+            // If ZRX is the maker token, the Fee and the Maker amount need to be removed from the same pool;
+            // 200 ZRXwei for 2ZRXwei fee can only be filled once (need 202 ZRXwei)
+            const totalZRXTokenPooled = this.transferrableMakerTokenAmount;
             // The purchasing power here is less as the tokens are taken from the same Pool
             // For every one number of fills, we have to take an extra ZRX out of the pool
-            fillableTimesInMakerTokenUnits = totalZRXTokenPooled.dividedToIntegerBy(
+            fillableTimesInMakerTokenUnits = totalZRXTokenPooled.dividedBy(
                                                                      orderToFeeRatio.plus(new BigNumber(1)));
 
         }
-        const partiallyFillableMakerTokenAmount = fillableTimesInMakerTokenUnits.times(orderToFeeRatio);
-        const partiallyFillableFeeTokenAmount = fillableTimesInFeeTokenUnits.times(orderToFeeRatio);
-        return BigNumber.min(partiallyFillableMakerTokenAmount, partiallyFillableFeeTokenAmount);
+        // When Ratio is not fully divisible there can be remainders which cannot be represented, so they are floored.
+        // This can result in a RoundingError being thrown by the Exchange Contract.
+        const partiallyFillableMakerTokenAmount = fillableTimesInMakerTokenUnits.times(orderToFeeRatio).floor();
+        const partiallyFillableFeeTokenAmount = fillableTimesInFeeTokenBaseUnits.times(orderToFeeRatio).floor();
+        const partiallyFillableAmount = BigNumber.min(partiallyFillableMakerTokenAmount,
+                                                      partiallyFillableFeeTokenAmount);
+        return partiallyFillableAmount;
     }
 }

--- a/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
+++ b/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
@@ -1,0 +1,68 @@
+import {
+    SignedOrder,
+} from '../types';
+import { BigNumber } from 'bignumber.js';
+export class RemainingFillableCalculator {
+    private _signedOrder: SignedOrder;
+    private _isMakerTokenZRX: boolean;
+    private _transferrableMakerTokenAmount: BigNumber;
+    private _transferrableMakerFeeTokenAmount: BigNumber;
+    private _remainingMakerTokenAmount: BigNumber;
+    private _remainingMakerFeeAmount: BigNumber;
+    constructor(signedOrder: SignedOrder,
+                zrxAddress: string,
+                transferrableMakerTokenAmount: BigNumber,
+                transferrableMakerFeeTokenAmount: BigNumber,
+                remainingMakerTokenAmount: BigNumber) {
+        this._signedOrder = signedOrder;
+        this._isMakerTokenZRX = signedOrder.makerTokenAddress === zrxAddress;
+        this._transferrableMakerTokenAmount = transferrableMakerTokenAmount;
+        this._transferrableMakerFeeTokenAmount = transferrableMakerFeeTokenAmount;
+        this._remainingMakerTokenAmount = remainingMakerTokenAmount;
+        this._remainingMakerFeeAmount = remainingMakerTokenAmount.times(signedOrder.makerFee)
+                                                                 .dividedToIntegerBy(signedOrder.makerTokenAmount);
+    }
+    public computeRemainingMakerFillable(): BigNumber {
+        if (this.hasSufficientFundsForFeeAndTransferAmount()) {
+            return this._remainingMakerTokenAmount;
+        }
+        if (this._signedOrder.makerFee.isZero()) {
+            return BigNumber.min(this._remainingMakerTokenAmount, this._transferrableMakerTokenAmount);
+        } else {
+            return this.calculatePartiallyFillableMakerTokenAmount();
+        }
+    }
+    public computeRemainingTakerFillable(): BigNumber {
+        return this.computeRemainingMakerFillable().times(this._signedOrder.takerTokenAmount)
+                                                   .dividedToIntegerBy(this._signedOrder.makerTokenAmount);
+    }
+    private hasSufficientFundsForFeeAndTransferAmount(): boolean {
+        if (this._isMakerTokenZRX) {
+            const totalZRXTransferAmount = this._remainingMakerTokenAmount.plus(this._remainingMakerFeeAmount);
+            return this._transferrableMakerTokenAmount.gte(totalZRXTransferAmount);
+        } else {
+            const hasSufficientFundsForTransferAmount = this._transferrableMakerTokenAmount.gte(
+                                                            this._remainingMakerTokenAmount);
+            const hasSufficientFundsForFeeAmount = this._transferrableMakerFeeTokenAmount.gte(
+                                                       this._remainingMakerFeeAmount);
+            return (hasSufficientFundsForTransferAmount && hasSufficientFundsForFeeAmount);
+        }
+    }
+
+    private calculatePartiallyFillableMakerTokenAmount(): BigNumber {
+        const orderToFeeRatio = this._signedOrder.makerTokenAmount.dividedToIntegerBy(this._signedOrder.makerFee);
+        const fillableTimesInFeeToken = BigNumber.min(this._transferrableMakerFeeTokenAmount,
+                                                      this._remainingMakerFeeAmount);
+        let fillableTimesInMakerToken = this._transferrableMakerTokenAmount.dividedToIntegerBy(orderToFeeRatio);
+        if (this._isMakerTokenZRX) {
+            // when zrx == maker token transferrable maker == transfer
+            const totalZRXTokenPooled = this._transferrableMakerTokenAmount;
+            fillableTimesInMakerToken = totalZRXTokenPooled.dividedToIntegerBy(
+                                                             orderToFeeRatio.plus(new BigNumber(1)));
+
+        }
+        const partiallyFillableMakerTokenAmount = fillableTimesInMakerToken.times(orderToFeeRatio);
+        const partiallyFillableFeeTokenAmount = fillableTimesInFeeToken.times(orderToFeeRatio);
+        return BigNumber.min(partiallyFillableMakerTokenAmount, partiallyFillableFeeTokenAmount);
+    }
+}

--- a/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
+++ b/packages/0x.js/src/order_watcher/remaining_fillable_calculator.ts
@@ -51,16 +51,15 @@ export class RemainingFillableCalculator {
         }
     }
     private calculatePartiallyFillableMakerTokenAmount(): BigNumber {
-        // The number of times the maker can fill the order, if each fill only required the transfer of a single
-        // baseUnit of fee tokens.
         // Given an order for 200 wei for 2 ZRXwei fee, find 100 wei for 1 ZRXwei. Order ratio is then 100:1
         const orderToFeeRatio = this.signedOrder.makerTokenAmount.dividedBy(this.signedOrder.makerFee);
-        // Maximum number of times the Maker can fill the order, given the fees
+        // The number of times the maker can fill the order, if each fill only required the transfer of a single
+        // baseUnit of fee tokens.
         // Given 2 ZRXwei, the maximum amount of times Maker can fill this order, in terms of fees, is 2
         const fillableTimesInFeeTokenBaseUnits = BigNumber.min(this.transferrableMakerFeeTokenAmount,
                                                                this.remainingMakerFeeAmount);
-        // Maximum number of times the Maker can fill the order, given the Maker Token Balance
-        // Assuming a balance of 150 wei, maker can fill this order 1 time.
+        // The number of times the Maker can fill the order, given the Maker Token Balance
+        // Assuming a balance of 150 wei, and an orderToFeeRatio of 100:1, maker can fill this order 1 time.
         let fillableTimesInMakerTokenUnits = this.transferrableMakerTokenAmount.dividedBy(orderToFeeRatio);
         if (this.isMakerTokenZRX) {
             // If ZRX is the maker token, the Fee and the Maker amount need to be removed from the same pool;

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -88,7 +88,7 @@ export class OrderStateUtils {
              (transferrableFeeTokenAmount.greaterThanOrEqualTo(remainingFeeTokenAmount) &&
               transferrableMakerTokenAmount.greaterThanOrEqualTo(remainingMakerTokenAmount) &&
               signedOrder.makerTokenAddress !== zrxTokenAddress)) {
-            remainingFillableMakerTokenAmount = transferrableMakerTokenAmount;
+            remainingFillableMakerTokenAmount = remainingMakerTokenAmount;
         } else {
             remainingFillableMakerTokenAmount = this.calculatePartiallyFillableMakerTokenAmount(
               transferrableMakerTokenAmount, transferrableFeeTokenAmount, remainingMakerTokenAmount,

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -116,12 +116,12 @@ export class OrderStateUtils {
             return BigNumber.min(makerTransferrable, remainingMakerAmount);
         }
         const orderToFeeRatio = totalMakerAmount.dividedToIntegerBy(makerFee);
-        console.log('order to fee ratio: ', orderToFeeRatio.toString());
         let fillableTimesInMakerToken = makerTransferrable.dividedToIntegerBy(orderToFeeRatio);
         const fillableTimesInFeeToken = BigNumber.min(makerFeeTransferrable, remainingMakerFee);
         if (makerTokenAddress === zrxTokenAddress) {
           fillableTimesInMakerToken = makerTransferrable.plus(makerFeeTransferrable)
-                                                        .dividedToIntegerBy(orderToFeeRatio.plus(new BigNumber(1)));
+                                                        .dividedToIntegerBy(orderToFeeRatio.plus(
+                                                            ZeroEx.toBaseUnitAmount(new BigNumber(1), 18)));
 
         }
         return BigNumber.min(fillableTimesInMakerToken.times(orderToFeeRatio),

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -82,8 +82,9 @@ export class OrderStateUtils {
         const transferrableMakerTokenAmount = BigNumber.min([makerProxyAllowance, makerBalance]);
         const transferrableFeeTokenAmount = BigNumber.min([makerFeeProxyAllowance, makerFeeBalance]);
 
+        const isMakerTokenZRX = signedOrder.makerTokenAddress === zrxTokenAddress;
         const remainingFillableCalculator = new RemainingFillableCalculator(signedOrder,
-                                                zrxTokenAddress,
+                                                isMakerTokenZRX,
                                                 transferrableMakerTokenAmount,
                                                 transferrableFeeTokenAmount,
                                                 remainingMakerTokenAmount);

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -110,7 +110,13 @@ export class OrderStateUtils {
         if (makerFee.isZero()) {
             return BigNumber.min(makerTransferrable, remainingMakerAmount);
         }
+        if (makerFeeTransferrable.greaterThanOrEqualTo(makerFee) &&
+            makerTransferrable.greaterThanOrEqualTo(remainingMakerAmount) &&
+            makerTokenAddress !== zrxTokenAddress) {
+            return BigNumber.min(makerTransferrable, remainingMakerAmount);
+        }
         const orderToFeeRatio = totalMakerAmount.dividedToIntegerBy(makerFee);
+        console.log('order to fee ratio: ', orderToFeeRatio.toString());
         let fillableTimesInMakerToken = makerTransferrable.dividedToIntegerBy(orderToFeeRatio);
         const fillableTimesInFeeToken = BigNumber.min(makerFeeTransferrable, remainingMakerFee);
         if (makerTokenAddress === zrxTokenAddress) {

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -85,7 +85,7 @@ export class OrderStateUtils {
 
         let remainingFillableMakerTokenAmount;
         if (signedOrder.makerFee.isZero() ||
-             (transferrableFeeTokenAmount.greaterThanOrEqualTo(signedOrder.makerFee) &&
+             (transferrableFeeTokenAmount.greaterThanOrEqualTo(remainingFeeTokenAmount) &&
               transferrableMakerTokenAmount.greaterThanOrEqualTo(remainingMakerTokenAmount) &&
               signedOrder.makerTokenAddress !== zrxTokenAddress)) {
             remainingFillableMakerTokenAmount = transferrableMakerTokenAmount;
@@ -111,17 +111,17 @@ export class OrderStateUtils {
         };
         return orderRelevantState;
     }
-    private calculatePartiallyFillableMakerTokenAmount(makerTransferrable: BigNumber, makerFeeTransferrable: BigNumber,
-                                                       remainingMakerAmount: BigNumber, remainingMakerFee: BigNumber,
-                                                       totalMakerAmount: BigNumber, makerFee: BigNumber,
+    private calculatePartiallyFillableMakerTokenAmount(makerTransferrableAmount: BigNumber, makerFeeTransferrableAmount: BigNumber,
+                                                       remainingMakerAmount: BigNumber, remainingMakerFeeAmount: BigNumber,
+                                                       totalMakerAmount: BigNumber, makerFeeAmount: BigNumber,
                                                        makerTokenAddress: string, zrxTokenAddress: string): BigNumber {
-        const orderToFeeRatio = totalMakerAmount.dividedToIntegerBy(makerFee);
-        let fillableTimesInMakerToken = makerTransferrable.dividedToIntegerBy(orderToFeeRatio);
-        const fillableTimesInFeeToken = BigNumber.min(makerFeeTransferrable, remainingMakerFee);
+        const orderToFeeRatio = totalMakerAmount.dividedToIntegerBy(makerFeeAmount);
+        const fillableTimesInFeeToken = BigNumber.min(makerFeeTransferrableAmount, remainingMakerFeeAmount);
+        let fillableTimesInMakerToken = makerTransferrableAmount.dividedToIntegerBy(orderToFeeRatio);
         if (makerTokenAddress === zrxTokenAddress) {
-          fillableTimesInMakerToken = makerTransferrable.plus(makerFeeTransferrable)
-                                                        .dividedToIntegerBy(orderToFeeRatio.plus(
-                                                            ZeroEx.toBaseUnitAmount(new BigNumber(1), 18)));
+            const totalFeeTokenPool = makerTransferrableAmount.plus(makerFeeTransferrableAmount);
+            fillableTimesInMakerToken = totalFeeTokenPool.dividedToIntegerBy(
+                                                             orderToFeeRatio.plus(ZeroEx.toBaseUnitAmount(new BigNumber(1), 18)));
 
         }
         return BigNumber.min(fillableTimesInMakerToken.times(orderToFeeRatio),

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -111,11 +111,8 @@ export class OrderStateUtils {
             return BigNumber.min(makerTransferrable, remainingMakerAmount);
         }
         const orderToFeeRatio = totalMakerAmount.dividedToIntegerBy(makerFee);
-        console.log('Order to Fee Ratio: ', orderToFeeRatio.toString());
         let fillableTimesInMakerToken = makerTransferrable.dividedToIntegerBy(orderToFeeRatio);
-        console.log('Fillable Token Times: ', fillableTimesInMakerToken.toString());
         const fillableTimesInFeeToken = BigNumber.min(makerFeeTransferrable, remainingMakerFee);
-        console.log('Fillable Fee Times: ', fillableTimesInFeeToken.toString());
         if (makerTokenAddress === zrxTokenAddress) {
           fillableTimesInMakerToken = makerTransferrable.plus(makerFeeTransferrable)
                                                         .dividedToIntegerBy(orderToFeeRatio.plus(new BigNumber(1)));

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -17,7 +17,6 @@ import {utils} from '../utils/utils';
 import {constants} from '../utils/constants';
 import {OrderFilledCancelledLazyStore} from '../stores/order_filled_cancelled_lazy_store';
 import {BalanceAndProxyAllowanceLazyStore} from '../stores/balance_proxy_allowance_lazy_store';
-import { TokenTransferProxyWrapper } from '../contract_wrappers/token_transfer_proxy_wrapper';
 
 const ACCEPTABLE_RELATIVE_ROUNDING_ERROR = 0.0001;
 

--- a/packages/0x.js/src/utils/order_state_utils.ts
+++ b/packages/0x.js/src/utils/order_state_utils.ts
@@ -131,7 +131,7 @@ export class OrderStateUtils {
             return BigNumber.min(remainingMakerAmount, transferrableMakerTokenAmount);
         } else if (transferrableMakerTokenAmount.gte(remainingMakerAmount) &&
                    transferrableMakerFeeTokenAmount.gte(remainingMakerFeeAmount)) {
-            return transferrableMakerTokenAmount;
+            return remainingMakerAmount;
         } else {
             return this.calculatePartiallyFillableMakerTokenAmount(
               transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerAmount,

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -326,6 +326,7 @@ describe('OrderStateWatcher', () => {
                     await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
 
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
+                        expect(orderState.isValid).to.be.true();
                         const validOrderState = orderState as OrderStateValid;
                         const orderRelevantState = validOrderState.orderRelevantState;
                         expect(orderRelevantState.remainingFillableMakerTokenAmount).to.be.bignumber.equal(
@@ -352,7 +353,7 @@ describe('OrderStateWatcher', () => {
 
                     const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(4), decimals);
                     const transferTokenAmount = makerFee.sub(remainingTokenAmount);
-                    zeroEx.orderStateWatcher.addOrder(signedOrder);
+                    await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
 
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
                         expect(orderState.isValid).to.be.true();
@@ -382,7 +383,7 @@ describe('OrderStateWatcher', () => {
 
                     const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(4), decimals);
                     const transferTokenAmount = makerFee.sub(remainingTokenAmount);
-                    zeroEx.orderStateWatcher.addOrder(signedOrder);
+                    await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
 
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
                         const validOrderState = orderState as OrderStateValid;
@@ -407,7 +408,7 @@ describe('OrderStateWatcher', () => {
                         taker, fillableAmount, feeRecipient);
 
                     const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
-                    zeroEx.orderStateWatcher.addOrder(signedOrder);
+                    await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
 
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
                         const validOrderState = orderState as OrderStateValid;

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -32,7 +32,7 @@ chaiSetup.configure();
 const expect = chai.expect;
 const blockchainLifecycle = new BlockchainLifecycle();
 
-describe('OrderStateWatcher', () => {
+describe.only('OrderStateWatcher', () => {
     let web3: Web3;
     let zeroEx: ZeroEx;
     let tokens: Token[];

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -335,7 +335,7 @@ describe('OrderStateWatcher', () => {
                     const remainingFeeAmount = ZeroEx.toBaseUnitAmount(new BigNumber(3), 18);
                     const transferFeeAmount = makerFee.sub(remainingFeeAmount);
 
-                    const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(3), 18);
+                    const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(1), 18);
                     const transferTokenAmount = makerFee.sub(remainingFeeAmount);
                     zeroEx.orderStateWatcher.addOrder(signedOrder);
 
@@ -343,15 +343,13 @@ describe('OrderStateWatcher', () => {
                         const validOrderState = orderState as OrderStateValid;
                         const orderRelevantState = validOrderState.orderRelevantState;
                         expect(orderRelevantState.remainingFillableMakerTokenAmount).to.be.bignumber.equal(
-                            remainingAmount);
-                        expect(orderRelevantState.remainingFillableTakerTokenAmount).to.be.bignumber.equal(
-                            remainingAmount);
+                            remainingFeeAmount);
                         done();
                     });
                     zeroEx.orderStateWatcher.subscribe(callback);
-                    await zeroEx.token.setProxyAllowanceAsync(zrxTokenAddress, maker, remainingAmount);
-                    // await zeroEx.token.transferAsync(
-                    //     zrxTokenAddress, maker, ZeroEx.NULL_ADDRESS, transferAmount);
+                    await zeroEx.token.setProxyAllowanceAsync(zrxTokenAddress, maker, remainingFeeAmount);
+                    await zeroEx.token.transferAsync(
+                        makerToken.address, maker, ZeroEx.NULL_ADDRESS, transferTokenAmount);
                 })().catch(done);
             });
         });

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -25,7 +25,7 @@ import {FillScenarios} from './utils/fill_scenarios';
 import {DoneCallback} from '../src/types';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
 import {reportCallbackErrors} from './utils/report_callback_errors';
-import { constants as constants } from './utils/constants';
+import {constants as constants} from './utils/constants';
 
 const TIMEOUT_MS = 150;
 

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -32,7 +32,7 @@ chaiSetup.configure();
 const expect = chai.expect;
 const blockchainLifecycle = new BlockchainLifecycle();
 
-describe.only('OrderStateWatcher', () => {
+describe('OrderStateWatcher', () => {
     let web3: Web3;
     let zeroEx: ZeroEx;
     let tokens: Token[];

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -3,10 +3,10 @@ import * as chai from 'chai';
 import * as _ from 'lodash';
 import * as Web3 from 'web3';
 import BigNumber from 'bignumber.js';
-import { chaiSetup } from './utils/chai_setup';
-import { web3Factory } from './utils/web3_factory';
-import { Web3Wrapper } from '../src/web3_wrapper';
-import { OrderStateWatcher } from '../src/order_watcher/order_state_watcher';
+import {chaiSetup} from './utils/chai_setup';
+import {web3Factory} from './utils/web3_factory';
+import {Web3Wrapper} from '../src/web3_wrapper';
+import {OrderStateWatcher} from '../src/order_watcher/order_state_watcher';
 import {
     Token,
     ZeroEx,
@@ -20,11 +20,12 @@ import {
     OrderStateInvalid,
     ExchangeContractErrs,
 } from '../src';
-import { TokenUtils } from './utils/token_utils';
-import { FillScenarios } from './utils/fill_scenarios';
-import { DoneCallback } from '../src/types';
+import {TokenUtils} from './utils/token_utils';
+import {FillScenarios} from './utils/fill_scenarios';
+import {DoneCallback} from '../src/types';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
 import {reportCallbackErrors} from './utils/report_callback_errors';
+import { constants as constants } from './utils/constants';
 
 const TIMEOUT_MS = 150;
 
@@ -47,7 +48,8 @@ describe('OrderStateWatcher', () => {
     let taker: string;
     let web3Wrapper: Web3Wrapper;
     let signedOrder: SignedOrder;
-    const fillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(5), 18);
+    const decimals = constants.ZRX_DECIMALS;
+    const fillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(5), decimals);
     before(async () => {
         web3 = web3Factory.create();
         zeroEx = new ZeroEx(web3.currentProvider);
@@ -238,15 +240,15 @@ describe('OrderStateWatcher', () => {
         describe('remainingFillable(M|T)akerTokenAmount', () => {
             it('should calculate correct remaining fillable', (done: DoneCallback) => {
                 (async () => {
-                    const takerFillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(10), 18);
-                    const makerFillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(20), 18);
+                    const takerFillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(10), decimals);
+                    const makerFillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(20), decimals);
                     signedOrder = await fillScenarios.createAsymmetricFillableSignedOrderAsync(
                         makerToken.address, takerToken.address, maker, taker, makerFillableAmount,
                         takerFillableAmount,
                     );
                     const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
                     const takerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, taker);
-                    const fillAmountInBaseUnits = ZeroEx.toBaseUnitAmount(new BigNumber(2), 18);
+                    const fillAmountInBaseUnits = ZeroEx.toBaseUnitAmount(new BigNumber(2), decimals);
                     const orderHash = ZeroEx.getOrderHashHex(signedOrder);
                     zeroEx.orderStateWatcher.addOrder(signedOrder);
                     let eventCount = 0;
@@ -257,9 +259,9 @@ describe('OrderStateWatcher', () => {
                         expect(validOrderState.orderHash).to.be.equal(orderHash);
                         const orderRelevantState = validOrderState.orderRelevantState;
                         expect(orderRelevantState.remainingFillableMakerTokenAmount).to.be.bignumber.equal(
-                            ZeroEx.toBaseUnitAmount(new BigNumber(16), 18));
+                            ZeroEx.toBaseUnitAmount(new BigNumber(16), decimals));
                         expect(orderRelevantState.remainingFillableTakerTokenAmount).to.be.bignumber.equal(
-                            ZeroEx.toBaseUnitAmount(new BigNumber(8), 18));
+                            ZeroEx.toBaseUnitAmount(new BigNumber(8), decimals));
                         if (eventCount === 2) {
                             done();
                         }
@@ -279,7 +281,7 @@ describe('OrderStateWatcher', () => {
 
                     const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
 
-                    const changedMakerApprovalAmount = ZeroEx.toBaseUnitAmount(new BigNumber(3), 18);
+                    const changedMakerApprovalAmount = ZeroEx.toBaseUnitAmount(new BigNumber(3), decimals);
                     zeroEx.orderStateWatcher.addOrder(signedOrder);
 
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
@@ -303,7 +305,7 @@ describe('OrderStateWatcher', () => {
 
                     const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
 
-                    const remainingAmount = ZeroEx.toBaseUnitAmount(new BigNumber(1), 18);
+                    const remainingAmount = ZeroEx.toBaseUnitAmount(new BigNumber(1), decimals);
                     const transferAmount = makerBalance.sub(remainingAmount);
                     zeroEx.orderStateWatcher.addOrder(signedOrder);
 
@@ -323,8 +325,8 @@ describe('OrderStateWatcher', () => {
             });
             it('should equal remaining amount when partially cancelled and order has fees', (done: DoneCallback) => {
                 (async () => {
-                    const takerFee = ZeroEx.toBaseUnitAmount(new BigNumber(0), 18);
-                    const makerFee = ZeroEx.toBaseUnitAmount(new BigNumber(5), 18);
+                    const takerFee = ZeroEx.toBaseUnitAmount(new BigNumber(0), decimals);
+                    const makerFee = ZeroEx.toBaseUnitAmount(new BigNumber(5), decimals);
                     const feeRecipient = taker;
                     signedOrder = await fillScenarios.createFillableSignedOrderWithFeesAsync(
                         makerToken.address, takerToken.address, makerFee, takerFee, maker,
@@ -332,11 +334,12 @@ describe('OrderStateWatcher', () => {
 
                     const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
 
-                    const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(4), 18);
+                    const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(4), decimals);
                     const transferTokenAmount = makerFee.sub(remainingTokenAmount);
                     zeroEx.orderStateWatcher.addOrder(signedOrder);
 
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
+                        expect(orderState.isValid).to.be.true();
                         const validOrderState = orderState as OrderStateValid;
                         const orderRelevantState = validOrderState.orderRelevantState;
                         expect(orderRelevantState.remainingFillableMakerTokenAmount).to.be.bignumber.equal(
@@ -349,8 +352,8 @@ describe('OrderStateWatcher', () => {
             });
             it('should equal ratio amount when fee balance is lowered', (done: DoneCallback) => {
                 (async () => {
-                    const takerFee = ZeroEx.toBaseUnitAmount(new BigNumber(0), 18);
-                    const makerFee = ZeroEx.toBaseUnitAmount(new BigNumber(5), 18);
+                    const takerFee = ZeroEx.toBaseUnitAmount(new BigNumber(0), decimals);
+                    const makerFee = ZeroEx.toBaseUnitAmount(new BigNumber(5), decimals);
                     const feeRecipient = taker;
                     signedOrder = await fillScenarios.createFillableSignedOrderWithFeesAsync(
                         makerToken.address, takerToken.address, makerFee, takerFee, maker,
@@ -358,10 +361,10 @@ describe('OrderStateWatcher', () => {
 
                     const makerBalance = await zeroEx.token.getBalanceAsync(makerToken.address, maker);
 
-                    const remainingFeeAmount = ZeroEx.toBaseUnitAmount(new BigNumber(3), 18);
+                    const remainingFeeAmount = ZeroEx.toBaseUnitAmount(new BigNumber(3), decimals);
                     const transferFeeAmount = makerFee.sub(remainingFeeAmount);
 
-                    const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(4), 18);
+                    const remainingTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(4), decimals);
                     const transferTokenAmount = makerFee.sub(remainingTokenAmount);
                     zeroEx.orderStateWatcher.addOrder(signedOrder);
 
@@ -380,8 +383,8 @@ describe('OrderStateWatcher', () => {
             });
             it('should calculate full amount when all available and non-divisible', (done: DoneCallback) => {
                 (async () => {
-                    const takerFee = ZeroEx.toBaseUnitAmount(new BigNumber(0), 18);
-                    const makerFee = ZeroEx.toBaseUnitAmount(new BigNumber(2), 18);
+                    const takerFee = ZeroEx.toBaseUnitAmount(new BigNumber(0), decimals);
+                    const makerFee = ZeroEx.toBaseUnitAmount(new BigNumber(2), decimals);
                     const feeRecipient = taker;
                     signedOrder = await fillScenarios.createFillableSignedOrderWithFeesAsync(
                         makerToken.address, takerToken.address, makerFee, takerFee, maker,
@@ -399,7 +402,7 @@ describe('OrderStateWatcher', () => {
                     });
                     zeroEx.orderStateWatcher.subscribe(callback);
                     await zeroEx.token.setProxyAllowanceAsync(
-                        makerToken.address, maker, ZeroEx.toBaseUnitAmount(new BigNumber(100), 18));
+                        makerToken.address, maker, ZeroEx.toBaseUnitAmount(new BigNumber(100), decimals));
                 })().catch(done);
             });
         });

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -235,7 +235,7 @@ describe('OrderStateWatcher', () => {
                 );
             })().catch(done);
         });
-        describe.only('remainingFillable(M|T)akerTokenAmount', () => {
+        describe('remainingFillable(M|T)akerTokenAmount', () => {
             it('should calculate correct remaining fillable', (done: DoneCallback) => {
                 (async () => {
                     const takerFillableAmount = ZeroEx.toBaseUnitAmount(new BigNumber(10), 18);

--- a/packages/0x.js/test/remaining_fillable_calculator_test.ts
+++ b/packages/0x.js/test/remaining_fillable_calculator_test.ts
@@ -10,7 +10,7 @@ import { ZeroEx } from '../src/0x';
 chaiSetup.configure();
 const expect = chai.expect;
 
-describe.only('RemainingFillableCalculator', () => {
+describe('RemainingFillableCalculator', () => {
     let calculator: RemainingFillableCalculator;
     let signedOrder: SignedOrder;
     let transferrableMakerTokenAmount: BigNumber;

--- a/packages/0x.js/test/remaining_fillable_calculator_test.ts
+++ b/packages/0x.js/test/remaining_fillable_calculator_test.ts
@@ -1,0 +1,89 @@
+import 'mocha';
+import * as chai from 'chai';
+import BigNumber from 'bignumber.js';
+import { chaiSetup } from './utils/chai_setup';
+import { RemainingFillableCalculator } from '../src/order_watcher/remaining_fillable_calculator';
+import { SignedOrder, ECSignature } from '../src/types';
+import { TokenUtils } from './utils/token_utils';
+
+chaiSetup.configure();
+const expect = chai.expect;
+
+describe.only('RemainingFillableCalculator', () => {
+    let calculator: RemainingFillableCalculator;
+    let signedOrder: SignedOrder;
+    let makerToken: string;
+    let takerToken: string;
+    let zrxToken: string;
+    let transferrableMakerTokenAmount: BigNumber;
+    let transferrableMakerFeeTokenAmount: BigNumber;
+    let remainingMakerTokenAmount: BigNumber;
+    let makerAmount: BigNumber;
+    let takerAmount: BigNumber;
+    let makerFee: BigNumber;
+    const zero: BigNumber = new BigNumber(0);
+    const zeroAddress = '0x0';
+    const signature: ECSignature = { v: 27, r: '', s: ''};
+    before(async () => {
+        [makerToken, takerToken, zrxToken] = ['0x1', '0x2', '0x3'];
+        [makerAmount, takerAmount, makerFee] = [new BigNumber(50), new BigNumber(5), new BigNumber(1)];
+    });
+    function buildSignedOrder(): SignedOrder {
+        return { ecSignature: signature,
+                 exchangeContractAddress: zeroAddress,
+                 feeRecipient: zeroAddress,
+                 maker: zeroAddress,
+                 taker: zeroAddress,
+                 makerFee: (makerFee || zero),
+                 takerFee: zero,
+                 makerTokenAmount: makerAmount,
+                 takerTokenAmount: takerAmount,
+                 makerTokenAddress: makerToken,
+                 takerTokenAddress: takerToken,
+                 salt: zero,
+                 expirationUnixTimestampSec: zero };
+    }
+    it('calculates the correct amount when partially filled and funds available', () => {
+        signedOrder = buildSignedOrder();
+        remainingMakerTokenAmount = new BigNumber(1);
+        transferrableMakerTokenAmount = new BigNumber(100);
+        transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
+        calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
+                       transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
+        expect(calculator.computeRemainingMakerFillable()).to.be.bignumber.equal(remainingMakerTokenAmount);
+    });
+    describe('Maker token is NOT ZRX', () => {
+        it('calculates the amount to be 0 when all fee funds move', () => {
+            signedOrder = buildSignedOrder();
+            transferrableMakerTokenAmount = new BigNumber(100);
+            transferrableMakerFeeTokenAmount = zero;
+            remainingMakerTokenAmount = signedOrder.makerTokenAmount;
+            calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
+                           transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
+            expect(calculator.computeRemainingMakerFillable()).to.be.bignumber.equal(zero);
+        });
+    });
+    describe('Maker Token is ZRX', () => {
+        before(async () => {
+            makerToken = zrxToken;
+        });
+        it('calculates the correct amount when partially filled and funds available', () => {
+            signedOrder = buildSignedOrder();
+            transferrableMakerTokenAmount = new BigNumber(100);
+            transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
+            remainingMakerTokenAmount = new BigNumber(1);
+            calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
+                           transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
+            expect(calculator.computeRemainingMakerFillable()).to.be.bignumber.equal(remainingMakerTokenAmount);
+        });
+        it('calculates the amount to be 0 when all fee funds move', () => {
+            signedOrder = buildSignedOrder();
+            transferrableMakerTokenAmount = zero;
+            transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
+            remainingMakerTokenAmount = signedOrder.makerTokenAmount;
+            calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
+                           transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
+            expect(calculator.computeRemainingMakerFillable()).to.be.bignumber.equal(zero);
+        });
+    });
+});

--- a/packages/0x.js/test/remaining_fillable_calculator_test.ts
+++ b/packages/0x.js/test/remaining_fillable_calculator_test.ts
@@ -122,15 +122,15 @@ describe.only('RemainingFillableCalculator', () => {
             transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
 
             const orderToFeeRatio = signedOrder.makerTokenAmount.dividedToIntegerBy(signedOrder.makerFee);
-            const expectedRemainingAmount = new BigNumber(450950);
-            const numberOfFillsInRatio = expectedRemainingAmount.dividedToIntegerBy(orderToFeeRatio);
+            const expectedFillableAmount = new BigNumber(450950);
+            const numberOfFillsInRatio = expectedFillableAmount.dividedToIntegerBy(orderToFeeRatio);
             calculator = new RemainingFillableCalculator(signedOrder, isMakerTokenZRX,
                            transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
-            const calculatedRemainingAmount = calculator.computeRemainingMakerFillable();
-            const calculatedRemainingAmountPlusFees = calculatedRemainingAmount.plus(numberOfFillsInRatio);
-            expect(calculatedRemainingAmount).to.be.bignumber.equal(expectedRemainingAmount);
-            expect(calculatedRemainingAmountPlusFees).to.be.bignumber.lessThan(transferrableMakerTokenAmount);
-            expect(calculatedRemainingAmountPlusFees).to.be.bignumber.lessThan(remainingMakerTokenAmount);
+            const calculatedFillableAmount = calculator.computeRemainingMakerFillable();
+            const calculatedFillableAmountPlusFees = calculatedFillableAmount.plus(numberOfFillsInRatio);
+            expect(calculatedFillableAmount).to.be.bignumber.equal(expectedFillableAmount);
+            expect(calculatedFillableAmountPlusFees).to.be.bignumber.lessThan(transferrableMakerTokenAmount);
+            expect(calculatedFillableAmountPlusFees).to.be.bignumber.lessThan(remainingMakerTokenAmount);
         });
     });
 });

--- a/packages/0x.js/test/remaining_fillable_calculator_test.ts
+++ b/packages/0x.js/test/remaining_fillable_calculator_test.ts
@@ -5,6 +5,7 @@ import { chaiSetup } from './utils/chai_setup';
 import { RemainingFillableCalculator } from '../src/order_watcher/remaining_fillable_calculator';
 import { SignedOrder, ECSignature } from '../src/types';
 import { TokenUtils } from './utils/token_utils';
+import { ZeroEx } from '../src/0x';
 
 chaiSetup.configure();
 const expect = chai.expect;
@@ -26,7 +27,12 @@ describe.only('RemainingFillableCalculator', () => {
     const signature: ECSignature = { v: 27, r: '', s: ''};
     before(async () => {
         [makerToken, takerToken, zrxToken] = ['0x1', '0x2', '0x3'];
-        [makerAmount, takerAmount, makerFee] = [new BigNumber(50), new BigNumber(5), new BigNumber(1)];
+        [makerAmount, takerAmount, makerFee] = [ZeroEx.toBaseUnitAmount(new BigNumber(50), 18),
+                                                ZeroEx.toBaseUnitAmount(new BigNumber(5), 18),
+                                                ZeroEx.toBaseUnitAmount(new BigNumber(1), 18)];
+        [transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount] = [
+                                                ZeroEx.toBaseUnitAmount(new BigNumber(50), 18),
+                                                ZeroEx.toBaseUnitAmount(new BigNumber(5), 18)];
     });
     function buildSignedOrder(): SignedOrder {
         return { ecSignature: signature,
@@ -45,9 +51,7 @@ describe.only('RemainingFillableCalculator', () => {
     }
     it('calculates the correct amount when partially filled and funds available', () => {
         signedOrder = buildSignedOrder();
-        remainingMakerTokenAmount = new BigNumber(1);
-        transferrableMakerTokenAmount = new BigNumber(100);
-        transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
+        remainingMakerTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(1), 18);
         calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
                        transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
         expect(calculator.computeRemainingMakerFillable()).to.be.bignumber.equal(remainingMakerTokenAmount);
@@ -55,7 +59,6 @@ describe.only('RemainingFillableCalculator', () => {
     describe('Maker token is NOT ZRX', () => {
         it('calculates the amount to be 0 when all fee funds move', () => {
             signedOrder = buildSignedOrder();
-            transferrableMakerTokenAmount = new BigNumber(100);
             transferrableMakerFeeTokenAmount = zero;
             remainingMakerTokenAmount = signedOrder.makerTokenAmount;
             calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
@@ -69,9 +72,7 @@ describe.only('RemainingFillableCalculator', () => {
         });
         it('calculates the correct amount when partially filled and funds available', () => {
             signedOrder = buildSignedOrder();
-            transferrableMakerTokenAmount = new BigNumber(100);
-            transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
-            remainingMakerTokenAmount = new BigNumber(1);
+            remainingMakerTokenAmount = ZeroEx.toBaseUnitAmount(new BigNumber(1), 18);
             calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
                            transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);
             expect(calculator.computeRemainingMakerFillable()).to.be.bignumber.equal(remainingMakerTokenAmount);
@@ -79,7 +80,7 @@ describe.only('RemainingFillableCalculator', () => {
         it('calculates the amount to be 0 when all fee funds move', () => {
             signedOrder = buildSignedOrder();
             transferrableMakerTokenAmount = zero;
-            transferrableMakerFeeTokenAmount = transferrableMakerTokenAmount;
+            transferrableMakerFeeTokenAmount = zero;
             remainingMakerTokenAmount = signedOrder.makerTokenAmount;
             calculator = new RemainingFillableCalculator(signedOrder, zrxToken,
                            transferrableMakerTokenAmount, transferrableMakerFeeTokenAmount, remainingMakerTokenAmount);

--- a/packages/0x.js/test/utils/constants.ts
+++ b/packages/0x.js/test/utils/constants.ts
@@ -5,4 +5,5 @@ export const constants = {
     TESTRPC_NETWORK_ID: 50,
     KOVAN_RPC_URL: 'https://kovan.infura.io',
     ROPSTEN_RPC_URL: 'https://ropsten.infura.io',
+    ZRX_DECIMALS: 18,
 };


### PR DESCRIPTION
This PR:
* Handles the case when `feeToken` is transferred but the `makerToken` balance is satisfactory.
* Handle the case when MakerToken and FeeToken both are ZRX (pooled).
* Handle the case when Maker Token and FeeToken are different (non-pooled).
* Calculate the maximum partially fillable amount
* handle the case where Order to Fee Ratio is < 1