### PR TITLE
Add postFormatter for logs

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -2,18 +2,19 @@
 
 vx.x.x
 ------------------------
-    * Remove support for Async callback types when used in Subscribe functions
+    * Add post-formatter for logs converting `blockNumber`, `logIndex`, `transactionIndex` from hexes to numbers (#231)
+    * Remove support for Async callback types when used in Subscribe functions (#222)
     * In OrderWatcher subscribe to ZRX Token Transfer and Approval events when maker token is different (#225)
 
 v0.25.1 - _November 13, 2017_
 ------------------------
-    * Standardise on Cancelled over Canceled
-    * Add missing `DecodedLogEvent` type to exported types
-    * Normalized the transactionReceipt status to be `null|0|1`, 1 meaning transaction execution successful, 0 unsuccessful and `null` if it is a pre-byzantinium transaction. 
+    * Standardise on Cancelled over Canceled (#217)
+    * Add missing `DecodedLogEvent` type to exported types (#205)
+    * Normalized the transactionReceipt status to be `null|0|1`, 1 meaning transaction execution successful, 0 unsuccessful and `null` if it is a pre-byzantinium transaction. (#200)
 
 v0.23.0 - _November 12, 2017_
 ------------------------
-    *  Fixed unhandled promise rejection error in subscribe methods (#209)
+    * Fixed unhandled promise rejection error in subscribe methods (#209)
     * Subscribe callbacks now receive an error object as their first argument
 
 v0.22.6 - _November 10, 2017_

--- a/packages/0x.js/src/web3_wrapper.ts
+++ b/packages/0x.js/src/web3_wrapper.ts
@@ -5,6 +5,17 @@ import promisify = require('es6-promisify');
 import {ZeroExError, Artifact, TransactionReceipt} from './types';
 import {Contract} from './contract';
 
+interface RawLogEntry {
+    logIndex: string|null;
+    transactionIndex: string|null;
+    transactionHash: string;
+    blockHash: string|null;
+    blockNumber: string|null;
+    address: string;
+    data: string;
+    topics: string[];
+}
+
 export class Web3Wrapper {
     private web3: Web3;
     private defaults: Partial<Web3.TxData>;
@@ -137,8 +148,9 @@ export class Web3Wrapper {
             method: 'eth_getLogs',
             params: [serializedFilter],
         };
-        const logs = await this.sendRawPayloadAsync(payload);
-        return logs;
+        const rawLogs = await this.sendRawPayloadAsync<RawLogEntry[]>(payload);
+        const formattedLogs = _.map(rawLogs, this.formatLog.bind(this));
+        return formattedLogs;
     }
     private getContractInstance<A extends Web3.ContractInstance>(abi: Web3.ContractAbi, address: string): A {
         const web3ContractInstance = this.web3.eth.contract(abi).at(address);
@@ -149,7 +161,7 @@ export class Web3Wrapper {
         const networkId = await promisify(this.web3.version.getNetwork)();
         return networkId;
     }
-    private async sendRawPayloadAsync(payload: Web3.JSONRPCRequestPayload): Promise<any> {
+    private async sendRawPayloadAsync<A>(payload: Web3.JSONRPCRequestPayload): Promise<A> {
         const sendAsync = this.web3.currentProvider.sendAsync.bind(this.web3.currentProvider);
         const response = await promisify(sendAsync)(payload);
         const result = response.result;
@@ -168,5 +180,21 @@ export class Web3Wrapper {
         } else {
             return status;
         }
+    }
+    private formatLog(rawLog: RawLogEntry): Web3.LogEntry {
+        const formattedLog = {
+            ...rawLog,
+            logIndex: this.toDecimal(rawLog.logIndex),
+            blockNumber: this.toDecimal(rawLog.blockNumber),
+            transactionIndex: this.toDecimal(rawLog.transactionIndex),
+        };
+        return formattedLog;
+    }
+    private toDecimal(hex: string|null): number|null {
+        if (_.isNull(hex)) {
+            return null;
+        }
+        const decimal = this.web3.toDecimal(hex);
+        return decimal;
     }
 }

--- a/packages/0x.js/src/web3_wrapper.ts
+++ b/packages/0x.js/src/web3_wrapper.ts
@@ -184,13 +184,13 @@ export class Web3Wrapper {
     private formatLog(rawLog: RawLogEntry): Web3.LogEntry {
         const formattedLog = {
             ...rawLog,
-            logIndex: this.toDecimal(rawLog.logIndex),
-            blockNumber: this.toDecimal(rawLog.blockNumber),
-            transactionIndex: this.toDecimal(rawLog.transactionIndex),
+            logIndex: this.hexToDecimal(rawLog.logIndex),
+            blockNumber: this.hexToDecimal(rawLog.blockNumber),
+            transactionIndex: this.hexToDecimal(rawLog.transactionIndex),
         };
         return formattedLog;
     }
-    private toDecimal(hex: string|null): number|null {
+    private hexToDecimal(hex: string|null): number|null {
         if (_.isNull(hex)) {
             return null;
         }

--- a/packages/0x.js/test/token_wrapper_test.ts
+++ b/packages/0x.js/test/token_wrapper_test.ts
@@ -361,6 +361,8 @@ describe('TokenWrapper', () => {
             (async () => {
                 const callback = (err: Error, logEvent: DecodedLogEvent<TransferContractEventArgs>) => {
                     expect(logEvent).to.not.be.undefined();
+                    expect(logEvent.logIndex).to.be.equal(0);
+                    expect(logEvent.transactionIndex).to.be.equal(0);
                     const args = logEvent.args;
                     expect(args._from).to.be.equal(coinbase);
                     expect(args._to).to.be.equal(addressWithoutFunds);

--- a/packages/0x.js/test/token_wrapper_test.ts
+++ b/packages/0x.js/test/token_wrapper_test.ts
@@ -363,6 +363,7 @@ describe('TokenWrapper', () => {
                     expect(logEvent).to.not.be.undefined();
                     expect(logEvent.logIndex).to.be.equal(0);
                     expect(logEvent.transactionIndex).to.be.equal(0);
+                    expect(logEvent.blockNumber).to.be.instanceOf(Number);
                     const args = logEvent.args;
                     expect(args._from).to.be.equal(coinbase);
                     expect(args._to).to.be.equal(addressWithoutFunds);


### PR DESCRIPTION
This PR:
* Adds post formatter for logs that convert hexes to numbers (logIndex, txIndex, blockNumber)
