### PR TITLE
Make DecodedLogEvent contain web3 log under a log subkey

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+vx.x.x
+------------------------
+    * Make `DecodedLogEvent<A>` contain `LogWithDecodedArgs<A>` under log key instead of merging it in like web3 does (#234)
+
 v0.26.0
 ------------------------
     * Add post-formatter for logs converting `blockNumber`, `logIndex`, `transactionIndex` from hexes to numbers (#231)

--- a/packages/0x.js/src/contract_wrappers/contract_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/contract_wrapper.ts
@@ -95,13 +95,13 @@ export class ContractWrapper {
             await this._web3Wrapper.getContractInstanceFromArtifactAsync<ContractType>(artifact, addressIfExists);
         return contractInstance;
     }
-    private _onLogStateChanged<ArgsType extends ContractEventArgs>(removed: boolean, log: Web3.LogEntry): void {
+    private _onLogStateChanged<ArgsType extends ContractEventArgs>(isRemoved: boolean, log: Web3.LogEntry): void {
         _.forEach(this._filters, (filter: Web3.FilterObject, filterToken: string) => {
             if (filterUtils.matchesFilter(log, filter)) {
                 const decodedLog = this._tryToDecodeLogOrNoop(log) as LogWithDecodedArgs<ArgsType>;
                 const logEvent = {
                     log: decodedLog,
-                    removed,
+                    isRemoved,
                 };
                 this._filterCallbacks[filterToken](null, logEvent);
             }
@@ -117,13 +117,13 @@ export class ContractWrapper {
         this._blockAndLogStreamInterval = intervalUtils.setAsyncExcludingInterval(
             this._reconcileBlockAsync.bind(this), constants.DEFAULT_BLOCK_POLLING_INTERVAL,
         );
-        let removed = false;
+        let isRemoved = false;
         this._onLogAddedSubscriptionToken = this._blockAndLogStreamer.subscribeToOnLogAdded(
-            this._onLogStateChanged.bind(this, removed),
+            this._onLogStateChanged.bind(this, isRemoved),
         );
-        removed = true;
+        isRemoved = true;
         this._onLogRemovedSubscriptionToken = this._blockAndLogStreamer.subscribeToOnLogRemoved(
-            this._onLogStateChanged.bind(this, removed),
+            this._onLogStateChanged.bind(this, isRemoved),
         );
     }
     private _stopBlockAndLogStream(): void {

--- a/packages/0x.js/src/contract_wrappers/contract_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/contract_wrapper.ts
@@ -100,7 +100,7 @@ export class ContractWrapper {
             if (filterUtils.matchesFilter(log, filter)) {
                 const decodedLog = this._tryToDecodeLogOrNoop(log) as LogWithDecodedArgs<ArgsType>;
                 const logEvent = {
-                    ...decodedLog,
+                    log: decodedLog,
                     removed,
                 };
                 this._filterCallbacks[filterToken](null, logEvent);

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -40,7 +40,10 @@ export type OrderValues = [BigNumber, BigNumber, BigNumber,
                            BigNumber, BigNumber, BigNumber];
 
 export type LogEvent = Web3.LogEntryEvent;
-export type DecodedLogEvent<ArgsType> = Web3.DecodedLogEntryEvent<ArgsType>;
+export interface DecodedLogEvent<ArgsType> {
+    removed: boolean;
+    log: LogWithDecodedArgs<ArgsType>;
+}
 
 export type EventCallback<ArgsType> = (err: null|Error, log?: DecodedLogEvent<ArgsType>) => void;
 export type EventWatcherCallback = (log: LogEvent) => void;

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -41,7 +41,7 @@ export type OrderValues = [BigNumber, BigNumber, BigNumber,
 
 export type LogEvent = Web3.LogEntryEvent;
 export interface DecodedLogEvent<ArgsType> {
-    removed: boolean;
+    isRemoved: boolean;
     log: LogWithDecodedArgs<ArgsType>;
 }
 

--- a/packages/0x.js/test/exchange_wrapper_test.ts
+++ b/packages/0x.js/test/exchange_wrapper_test.ts
@@ -649,7 +649,7 @@ describe('ExchangeWrapper', () => {
             (async () => {
 
                 const callback = (err: Error, logEvent: DecodedLogEvent<LogFillContractEventArgs>) => {
-                    expect(logEvent.event).to.be.equal(ExchangeEvents.LogFill);
+                    expect(logEvent.log.event).to.be.equal(ExchangeEvents.LogFill);
                     done();
                 };
                 await zeroEx.exchange.subscribeAsync(
@@ -665,7 +665,7 @@ describe('ExchangeWrapper', () => {
             (async () => {
 
                 const callback = (err: Error, logEvent: DecodedLogEvent<LogCancelContractEventArgs>) => {
-                    expect(logEvent.event).to.be.equal(ExchangeEvents.LogCancel);
+                    expect(logEvent.log.event).to.be.equal(ExchangeEvents.LogCancel);
                     done();
                 };
                 await zeroEx.exchange.subscribeAsync(
@@ -688,7 +688,7 @@ describe('ExchangeWrapper', () => {
                 await zeroEx.setProviderAsync(newProvider);
 
                 const callback = (err: Error, logEvent: DecodedLogEvent<LogFillContractEventArgs>) => {
-                    expect(logEvent.event).to.be.equal(ExchangeEvents.LogFill);
+                    expect(logEvent.log.event).to.be.equal(ExchangeEvents.LogFill);
                     done();
                 };
                 await zeroEx.exchange.subscribeAsync(

--- a/packages/0x.js/test/token_wrapper_test.ts
+++ b/packages/0x.js/test/token_wrapper_test.ts
@@ -361,7 +361,7 @@ describe('TokenWrapper', () => {
             (async () => {
                 const callback = (err: Error, logEvent: DecodedLogEvent<TransferContractEventArgs>) => {
                     expect(logEvent).to.not.be.undefined();
-                    expect(logEvent.removed).to.be.false();
+                    expect(logEvent.isRemoved).to.be.false();
                     expect(logEvent.log.logIndex).to.be.equal(0);
                     expect(logEvent.log.transactionIndex).to.be.equal(0);
                     expect(logEvent.log.blockNumber).to.be.a('number');
@@ -380,7 +380,7 @@ describe('TokenWrapper', () => {
             (async () => {
                 const callback = (err: Error, logEvent: DecodedLogEvent<ApprovalContractEventArgs>) => {
                     expect(logEvent).to.not.be.undefined();
-                    expect(logEvent.removed).to.be.false();
+                    expect(logEvent.isRemoved).to.be.false();
                     const args = logEvent.log.args;
                     expect(args._owner).to.be.equal(coinbase);
                     expect(args._spender).to.be.equal(addressWithoutFunds);

--- a/packages/0x.js/test/token_wrapper_test.ts
+++ b/packages/0x.js/test/token_wrapper_test.ts
@@ -361,10 +361,11 @@ describe('TokenWrapper', () => {
             (async () => {
                 const callback = (err: Error, logEvent: DecodedLogEvent<TransferContractEventArgs>) => {
                     expect(logEvent).to.not.be.undefined();
-                    expect(logEvent.logIndex).to.be.equal(0);
-                    expect(logEvent.transactionIndex).to.be.equal(0);
-                    expect(logEvent.blockNumber).to.be.a('number');
-                    const args = logEvent.args;
+                    expect(logEvent.removed).to.be.false();
+                    expect(logEvent.log.logIndex).to.be.equal(0);
+                    expect(logEvent.log.transactionIndex).to.be.equal(0);
+                    expect(logEvent.log.blockNumber).to.be.a('number');
+                    const args = logEvent.log.args;
                     expect(args._from).to.be.equal(coinbase);
                     expect(args._to).to.be.equal(addressWithoutFunds);
                     expect(args._value).to.be.bignumber.equal(transferAmount);
@@ -379,7 +380,8 @@ describe('TokenWrapper', () => {
             (async () => {
                 const callback = (err: Error, logEvent: DecodedLogEvent<ApprovalContractEventArgs>) => {
                     expect(logEvent).to.not.be.undefined();
-                    const args = logEvent.args;
+                    expect(logEvent.removed).to.be.false();
+                    const args = logEvent.log.args;
                     expect(args._owner).to.be.equal(coinbase);
                     expect(args._spender).to.be.equal(addressWithoutFunds);
                     expect(args._value).to.be.bignumber.equal(allowanceAmount);


### PR DESCRIPTION
This PR:
* Separates logs from log events
* Now log events contain log as a subkey which will simplify consumption of this type (inspired by OTC)
