### PR TITLE
Fix/validate orders against latest block

### DIFF
--- a/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
@@ -29,6 +29,7 @@ import {
     EventCallback,
     ExchangeContractEventArgs,
     DecodedLogArgs,
+    BlockParamLiteral,
 } from '../types';
 import {assert} from '../utils/assert';
 import {utils} from '../utils/utils';
@@ -178,7 +179,7 @@ export class ExchangeWrapper extends ContractWrapper {
             orderTransactionOpts.shouldValidate;
         if (shouldValidate) {
             const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
             await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
                 exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
         }
@@ -250,7 +251,7 @@ export class ExchangeWrapper extends ContractWrapper {
             orderTransactionOpts.shouldValidate;
         if (shouldValidate) {
             const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
             for (const signedOrder of signedOrders) {
                 await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
                     exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
@@ -340,7 +341,7 @@ export class ExchangeWrapper extends ContractWrapper {
             orderTransactionOpts.shouldValidate;
         if (shouldValidate) {
             const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
             for (const orderFillRequest of orderFillRequests) {
                 await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
                     exchangeTradeEmulator, orderFillRequest.signedOrder, orderFillRequest.takerTokenFillAmount,
@@ -420,7 +421,7 @@ export class ExchangeWrapper extends ContractWrapper {
             orderTransactionOpts.shouldValidate;
         if (shouldValidate) {
             const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
             await this._orderValidationUtils.validateFillOrKillOrderThrowIfInvalidAsync(
                 exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
         }
@@ -484,7 +485,7 @@ export class ExchangeWrapper extends ContractWrapper {
             orderTransactionOpts.shouldValidate;
         if (shouldValidate) {
             const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+            const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
             for (const orderFillRequest of orderFillRequests) {
                 await this._orderValidationUtils.validateFillOrKillOrderThrowIfInvalidAsync(
                     exchangeTradeEmulator, orderFillRequest.signedOrder, orderFillRequest.takerTokenFillAmount,
@@ -721,7 +722,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.doesConformToSchema('signedOrder', signedOrder, schemas.signedOrderSchema);
         const zrxTokenAddress = await this.getZRXTokenAddressAsync();
         const expectedFillTakerTokenAmount = !_.isUndefined(opts) ? opts.expectedFillTakerTokenAmount : undefined;
-        const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+        const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
         await this._orderValidationUtils.validateOrderFillableOrThrowAsync(
             exchangeTradeEmulator, signedOrder, zrxTokenAddress, expectedFillTakerTokenAmount,
         );
@@ -741,7 +742,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.isValidBaseUnitAmount('fillTakerTokenAmount', fillTakerTokenAmount);
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
         const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-        const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+        const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
         await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
             exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }
@@ -775,7 +776,7 @@ export class ExchangeWrapper extends ContractWrapper {
         assert.isValidBaseUnitAmount('fillTakerTokenAmount', fillTakerTokenAmount);
         await assert.isSenderAddressAsync('takerAddress', takerAddress, this._web3Wrapper);
         const zrxTokenAddress = await this.getZRXTokenAddressAsync();
-        const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper);
+        const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
         await this._orderValidationUtils.validateFillOrKillOrderThrowIfInvalidAsync(
             exchangeTradeEmulator, signedOrder, fillTakerTokenAmount, takerAddress, zrxTokenAddress);
     }

--- a/packages/0x.js/src/order_watcher/order_state_watcher.ts
+++ b/packages/0x.js/src/order_watcher/order_state_watcher.ts
@@ -74,7 +74,9 @@ export class OrderStateWatcher {
         this._web3Wrapper = web3Wrapper;
         const pollingIntervalIfExistsMs = _.isUndefined(config) ? undefined : config.eventPollingIntervalMs;
         this._eventWatcher = new EventWatcher(web3Wrapper, pollingIntervalIfExistsMs);
-        this._balanceAndProxyAllowanceLazyStore = new BalanceAndProxyAllowanceLazyStore(token);
+        this._balanceAndProxyAllowanceLazyStore = new BalanceAndProxyAllowanceLazyStore(
+            token, BlockParamLiteral.Pending,
+        );
         this._orderFilledCancelledLazyStore = new OrderFilledCancelledLazyStore(exchange);
         this._orderStateUtils = new OrderStateUtils(
             this._balanceAndProxyAllowanceLazyStore, this._orderFilledCancelledLazyStore,

--- a/packages/0x.js/src/stores/balance_proxy_allowance_lazy_store.ts
+++ b/packages/0x.js/src/stores/balance_proxy_allowance_lazy_store.ts
@@ -9,6 +9,7 @@ import {BlockParamLiteral} from '../types';
  */
 export class BalanceAndProxyAllowanceLazyStore {
     private token: TokenWrapper;
+    private defaultBlock: BlockParamLiteral;
     private balance: {
         [tokenAddress: string]: {
             [userAddress: string]: BigNumber,
@@ -19,15 +20,16 @@ export class BalanceAndProxyAllowanceLazyStore {
             [userAddress: string]: BigNumber,
         },
     };
-    constructor(token: TokenWrapper) {
+    constructor(token: TokenWrapper, defaultBlock: BlockParamLiteral) {
         this.token = token;
+        this.defaultBlock = defaultBlock;
         this.balance = {};
         this.proxyAllowance = {};
     }
     public async getBalanceAsync(tokenAddress: string, userAddress: string): Promise<BigNumber> {
         if (_.isUndefined(this.balance[tokenAddress]) || _.isUndefined(this.balance[tokenAddress][userAddress])) {
             const methodOpts = {
-                defaultBlock: BlockParamLiteral.Pending,
+                defaultBlock: this.defaultBlock,
             };
             const balance = await this.token.getBalanceAsync(tokenAddress, userAddress, methodOpts);
             this.setBalance(tokenAddress, userAddress, balance);
@@ -53,7 +55,7 @@ export class BalanceAndProxyAllowanceLazyStore {
         if (_.isUndefined(this.proxyAllowance[tokenAddress]) ||
             _.isUndefined(this.proxyAllowance[tokenAddress][userAddress])) {
             const methodOpts = {
-                defaultBlock: BlockParamLiteral.Pending,
+                defaultBlock: this.defaultBlock,
             };
             const proxyAllowance = await this.token.getProxyAllowanceAsync(tokenAddress, userAddress, methodOpts);
             this.setProxyAllowance(tokenAddress, userAddress, proxyAllowance);

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -350,7 +350,6 @@ export interface IndexedFilterValues {
 
 export enum BlockParamLiteral {
     Latest = 'latest',
-    Earliest = 'earliest',
     Pending = 'pending',
 }
 

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -351,6 +351,9 @@ export interface IndexedFilterValues {
     [index: string]: ContractEventArg;
 }
 
+// Earliest is omitted by design. It is simply an alias for the `0` constant and
+// is thus not very helpful. Moreover, this type is used in places that only accept
+// `latest` or `pending`.
 export enum BlockParamLiteral {
     Latest = 'latest',
     Pending = 'pending',

--- a/packages/0x.js/src/utils/exchange_transfer_simulator.ts
+++ b/packages/0x.js/src/utils/exchange_transfer_simulator.ts
@@ -35,8 +35,8 @@ const ERR_MSG_MAPPING = {
 export class ExchangeTransferSimulator {
     private store: BalanceAndProxyAllowanceLazyStore;
     private UNLIMITED_ALLOWANCE_IN_BASE_UNITS: BigNumber;
-    constructor(token: TokenWrapper) {
-        this.store = new BalanceAndProxyAllowanceLazyStore(token);
+    constructor(token: TokenWrapper, defaultBlock: BlockParamLiteral) {
+        this.store = new BalanceAndProxyAllowanceLazyStore(token, defaultBlock);
         this.UNLIMITED_ALLOWANCE_IN_BASE_UNITS = token.UNLIMITED_ALLOWANCE_IN_BASE_UNITS;
     }
     /**

--- a/packages/0x.js/test/exchange_transfer_simulator_test.ts
+++ b/packages/0x.js/test/exchange_transfer_simulator_test.ts
@@ -37,7 +37,7 @@ describe('ExchangeTransferSimulator', () => {
     });
     describe('#transferFromAsync', () => {
         beforeEach(() => {
-            exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token);
+            exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token, BlockParamLiteral.Latest);
         });
         it('throws if the user doesn\'t have enough allowance', async () => {
             return expect(exchangeTransferSimulator.transferFromAsync(

--- a/packages/0x.js/test/exchange_transfer_simulator_test.ts
+++ b/packages/0x.js/test/exchange_transfer_simulator_test.ts
@@ -3,7 +3,7 @@ import BigNumber from 'bignumber.js';
 import {chaiSetup} from './utils/chai_setup';
 import {web3Factory} from './utils/web3_factory';
 import {ZeroEx, ExchangeContractErrs, Token} from '../src';
-import {TradeSide, TransferType} from '../src/types';
+import {TradeSide, TransferType, BlockParamLiteral} from '../src/types';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
 import {ExchangeTransferSimulator} from '../src/utils/exchange_transfer_simulator';
 

--- a/packages/0x.js/test/exchange_wrapper_test.ts
+++ b/packages/0x.js/test/exchange_wrapper_test.ts
@@ -754,7 +754,7 @@ describe('ExchangeWrapper', () => {
         const fillableAmount = new BigNumber(5);
         const shouldThrowOnInsufficientBalanceOrAllowance = true;
         const subscriptionOpts: SubscriptionOpts = {
-            fromBlock: BlockParamLiteral.Earliest,
+            fromBlock: 0,
             toBlock: BlockParamLiteral.Latest,
         };
         let txHash: string;

--- a/packages/0x.js/test/order_state_watcher_test.ts
+++ b/packages/0x.js/test/order_state_watcher_test.ts
@@ -180,16 +180,12 @@ describe('OrderStateWatcher', () => {
                 const orderHash = ZeroEx.getOrderHashHex(signedOrder);
                 await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
 
-                let eventCount = 0;
                 const callback = reportCallbackErrors(done)((orderState: OrderState) => {
-                    eventCount++;
                     expect(orderState.isValid).to.be.false();
                     const invalidOrderState = orderState as OrderStateInvalid;
                     expect(invalidOrderState.orderHash).to.be.equal(orderHash);
                     expect(invalidOrderState.error).to.be.equal(ExchangeContractErrs.OrderRemainingFillAmountZero);
-                    if (eventCount === 2) {
-                        done();
-                    }
+                    done();
                 });
                 zeroEx.orderStateWatcher.subscribe(callback);
 
@@ -212,9 +208,7 @@ describe('OrderStateWatcher', () => {
                 const orderHash = ZeroEx.getOrderHashHex(signedOrder);
                 await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
 
-                let eventCount = 0;
                 const callback = reportCallbackErrors(done)((orderState: OrderState) => {
-                    eventCount++;
                     expect(orderState.isValid).to.be.true();
                     const validOrderState = orderState as OrderStateValid;
                     expect(validOrderState.orderHash).to.be.equal(orderHash);
@@ -226,9 +220,7 @@ describe('OrderStateWatcher', () => {
                     expect(orderRelevantState.remainingFillableTakerTokenAmount).to.be.bignumber.equal(
                         remainingFillable);
                     expect(orderRelevantState.makerBalance).to.be.bignumber.equal(remainingMakerBalance);
-                    if (eventCount === 2) {
-                        done();
-                    }
+                    done();
                 });
                 zeroEx.orderStateWatcher.subscribe(callback);
                 const shouldThrowOnInsufficientBalanceOrAllowance = true;
@@ -267,9 +259,7 @@ describe('OrderStateWatcher', () => {
                     const fillAmountInBaseUnits = ZeroEx.toBaseUnitAmount(new BigNumber(2), decimals);
                     const orderHash = ZeroEx.getOrderHashHex(signedOrder);
                     await zeroEx.orderStateWatcher.addOrderAsync(signedOrder);
-                    let eventCount = 0;
                     const callback = reportCallbackErrors(done)((orderState: OrderState) => {
-                        eventCount++;
                         expect(orderState.isValid).to.be.true();
                         const validOrderState = orderState as OrderStateValid;
                         expect(validOrderState.orderHash).to.be.equal(orderHash);
@@ -278,9 +268,7 @@ describe('OrderStateWatcher', () => {
                             ZeroEx.toBaseUnitAmount(new BigNumber(16), decimals));
                         expect(orderRelevantState.remainingFillableTakerTokenAmount).to.be.bignumber.equal(
                             ZeroEx.toBaseUnitAmount(new BigNumber(8), decimals));
-                        if (eventCount === 2) {
-                            done();
-                        }
+                        done();
                     });
                     zeroEx.orderStateWatcher.subscribe(callback);
                     const shouldThrowOnInsufficientBalanceOrAllowance = true;

--- a/packages/0x.js/test/order_validation_test.ts
+++ b/packages/0x.js/test/order_validation_test.ts
@@ -5,7 +5,7 @@ import * as Sinon from 'sinon';
 import {chaiSetup} from './utils/chai_setup';
 import {web3Factory} from './utils/web3_factory';
 import {ZeroEx, SignedOrder, Token, ExchangeContractErrs, ZeroExError} from '../src';
-import {TradeSide, TransferType} from '../src/types';
+import {TradeSide, TransferType, BlockParamLiteral} from '../src/types';
 import {TokenUtils} from './utils/token_utils';
 import {BlockchainLifecycle} from './utils/blockchain_lifecycle';
 import {FillScenarios} from './utils/fill_scenarios';
@@ -215,7 +215,7 @@ describe('OrderValidation', () => {
             return Sinon.match((value: BigNumber) => value.eq(expected));
         };
         beforeEach('create exchangeTransferSimulator', async () => {
-            exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token);
+            exchangeTransferSimulator = new ExchangeTransferSimulator(zeroEx.token, BlockParamLiteral.Latest);
             transferFromAsync = Sinon.spy();
             exchangeTransferSimulator.transferFromAsync = transferFromAsync as any;
         });

--- a/packages/0x.js/test/token_wrapper_test.ts
+++ b/packages/0x.js/test/token_wrapper_test.ts
@@ -426,7 +426,7 @@ describe('TokenWrapper', () => {
         let tokenAddress: string;
         let tokenTransferProxyAddress: string;
         const subscriptionOpts: SubscriptionOpts = {
-            fromBlock: BlockParamLiteral.Earliest,
+            fromBlock: 0,
             toBlock: BlockParamLiteral.Latest,
         };
         let txHash: string;


### PR DESCRIPTION
This PR:
* Makes it such that order validation happens against the `latest` block, not the `pending` block. This fixes a bug for users of Infura, which does not have reliable support for querying state for the `pending` block.
