### PR TITLE
Add SignedOrder and TokenTradeInfo to public interface and fix a Http…

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+vx.x.x
+------------------------
+    * Add SignedOrder and TokenTradeInfo to the public interface
+
 v0.1.0 - _November 22, 2017_
 ------------------------
     * Provide a HttpClient class for interacting with standard relayer api compliant HTTP urls

--- a/packages/connect/src/http_client.ts
+++ b/packages/connect/src/http_client.ts
@@ -34,7 +34,7 @@ export class HttpClient implements Client {
     private apiEndpointUrl: string;
     /**
      * Instantiates a new HttpClient instance
-     * @param   url    The base url for making API calls
+     * @param   url    The relayer API base HTTP url you would like to interact with
      * @return  An instance of HttpClient
      */
     constructor(url: string) {

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -6,6 +6,8 @@ export {
     OrderbookRequest,
     OrderbookResponse,
     OrdersRequest,
+    SignedOrder,
     TokenPairsItem,
     TokenPairsRequest,
+    TokenTradeInfo,
 } from './types';

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -1,6 +1,8 @@
 import {SignedOrder} from '0x.js';
 import {BigNumber} from 'bignumber.js';
 
+export type SignedOrder = SignedOrder;
+
 export interface Client {
     getTokenPairsAsync: (request?: TokenPairsRequest) => Promise<TokenPairsItem[]>;
     getOrdersAsync: (request?: OrdersRequest) => Promise<SignedOrder[]>;


### PR DESCRIPTION
…Client comment

This PR:
* Added clearer description of the url argument for the HttpClient constructor
* Added SignedOrder and TokenTradeInfo to the public interface
