### PR TITLE
Update connect types in preperation for publishing

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -3,6 +3,7 @@
 vx.x.x
 ------------------------
     * Expose WebSocketOrderbookChannel and associated types to public interface (#251)
+    * Remove tokenA and tokenB fields from OrdersRequest (#256)
 
 v0.2.0 - _November 29, 2017_
 ------------------------

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -63,7 +63,7 @@ export interface OrderbookChannelHandler {
                order: SignedOrder) => void;
     onError: (channel: OrderbookChannel, subscriptionOpts: OrderbookChannelSubscriptionOpts,
               err: Error) => void;
-    onClose: (channel: OrderbookChannel) => void;
+    onClose: (channel: OrderbookChannel, subscriptionOpts: OrderbookChannelSubscriptionOpts) => void;
 }
 
 export type OrderbookChannelMessage =
@@ -128,8 +128,6 @@ export interface OrdersRequest {
     tokenAddress?: string;
     makerTokenAddress?: string;
     takerTokenAddress?: string;
-    tokenA?: string;
-    tokenB?: string;
     maker?: string;
     taker?: string;
     trader?: string;

--- a/packages/connect/src/ws_orderbook_channel.ts
+++ b/packages/connect/src/ws_orderbook_channel.ts
@@ -62,7 +62,7 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
                     handler.onError(this, subscriptionOpts, wsError);
                 });
                 connection.on(WebsocketConnectionEventType.Close, () => {
-                    handler.onClose(this);
+                    handler.onClose(this, subscriptionOpts);
                 });
                 connection.on(WebsocketConnectionEventType.Message, message => {
                     this._handleWebSocketMessage(subscribeMessage.requestId, subscriptionOpts, message, handler);

--- a/packages/connect/test/http_client_test.ts
+++ b/packages/connect/test/http_client_test.ts
@@ -61,12 +61,12 @@ describe('HttpClient', () => {
             const orders = await relayerClient.getOrdersAsync();
             expect(orders).to.be.deep.equal(ordersResponse);
         });
-        it('gets specfic orders for request', async () => {
+        it('gets specific orders for request', async () => {
             const tokenAddress = '0x323b5d4c32345ced77393b3530b1eed0f346429d';
             const ordersRequest = {
-                tokenA: tokenAddress,
+                tokenAddress,
             };
-            const urlWithQuery = `${url}?tokenA=${tokenAddress}`;
+            const urlWithQuery = `${url}?tokenAddress=${tokenAddress}`;
             fetchMock.get(urlWithQuery, ordersResponseJSON);
             const orders = await relayerClient.getOrdersAsync(ordersRequest);
             expect(orders).to.be.deep.equal(ordersResponse);


### PR DESCRIPTION
This PR:
* Add OrderbookChannelSubscriptionOpts to `onClose()` function in `OrderbookChannelHandler`
* Remove tokenA and tokenB fields from OrdersRequest
* These params were a bit confusing and the functionality is actually already possible via the tokenAddress param and the /orderbook endpoint
