### PR TITLE
Fix typedoc_utils to take into account subPackageName when rendering …

### DIFF
--- a/packages/website/ts/utils/typedoc_utils.ts
+++ b/packages/website/ts/utils/typedoc_utils.ts
@@ -103,7 +103,7 @@ export const typeDocUtils = {
                 case KindString.Constructor:
                     isConstructor = true;
                     const constructor = typeDocUtils._convertMethod(
-                        entity, isConstructor, docsInfo.sections, sectionName,
+                        entity, isConstructor, docsInfo.sections, sectionName, docsInfo.subPackageName,
                     );
                     docSection.constructors.push(constructor);
                     break;
@@ -112,7 +112,7 @@ export const typeDocUtils = {
                     if (entity.flags.isPublic) {
                         isConstructor = false;
                         const method = typeDocUtils._convertMethod(
-                            entity, isConstructor, docsInfo.sections, sectionName,
+                            entity, isConstructor, docsInfo.sections, sectionName, docsInfo.subPackageName,
                         );
                         docSection.methods.push(method);
                     }
@@ -120,7 +120,8 @@ export const typeDocUtils = {
 
                 case KindString.Property:
                     if (!typeDocUtils.isPrivateOrProtectedProperty(entity.name)) {
-                        const property = typeDocUtils._convertProperty(entity, docsInfo.sections, sectionName);
+                        const property = typeDocUtils._convertProperty(
+                            entity, docsInfo.sections, sectionName, docsInfo.subPackageName);
                         docSection.properties.push(property);
                     }
                     break;
@@ -131,7 +132,8 @@ export const typeDocUtils = {
                 case KindString.Enumeration:
                 case KindString['Type alias']:
                     if (docsInfo.isPublicType(entity.name)) {
-                        const customType = typeDocUtils._convertCustomType(entity, docsInfo.sections, sectionName);
+                        const customType = typeDocUtils._convertCustomType(
+                            entity, docsInfo.sections, sectionName, docsInfo.subPackageName);
                         docSection.types.push(customType);
                     }
                     break;
@@ -142,16 +144,17 @@ export const typeDocUtils = {
         });
         return docSection;
     },
-    _convertCustomType(entity: TypeDocNode, sections: SectionsMap, sectionName: string): CustomType {
+    _convertCustomType(entity: TypeDocNode, sections: SectionsMap, sectionName: string,
+                       subPackageName: string): CustomType {
         const typeIfExists = !_.isUndefined(entity.type) ?
-                             typeDocUtils._convertType(entity.type, sections, sectionName) :
+                             typeDocUtils._convertType(entity.type, sections, sectionName, subPackageName) :
                              undefined;
         const isConstructor = false;
         const methodIfExists = !_.isUndefined(entity.declaration) ?
-            typeDocUtils._convertMethod(entity.declaration, isConstructor, sections, sectionName) :
+            typeDocUtils._convertMethod(entity.declaration, isConstructor, sections, sectionName, subPackageName) :
             undefined;
         const indexSignatureIfExists = !_.isUndefined(entity.indexSignature) ?
-            typeDocUtils._convertIndexSignature(entity.indexSignature[0], sections, sectionName) :
+            typeDocUtils._convertIndexSignature(entity.indexSignature[0], sections, sectionName, subPackageName) :
             undefined;
         const commentIfExists = !_.isUndefined(entity.comment) && !_.isUndefined(entity.comment.shortText) ?
             entity.comment.shortText :
@@ -160,7 +163,7 @@ export const typeDocUtils = {
         const childrenIfExist = !_.isUndefined(entity.children) ?
             _.map(entity.children, (child: TypeDocNode) => {
                 const childTypeIfExists = !_.isUndefined(child.type) ?
-                    typeDocUtils._convertType(child.type, sections, sectionName) :
+                    typeDocUtils._convertType(child.type, sections, sectionName, subPackageName) :
                     undefined;
                 const c: CustomTypeChild = {
                     name: child.name,
@@ -183,21 +186,23 @@ export const typeDocUtils = {
         };
         return customType;
     },
-    _convertIndexSignature(entity: TypeDocNode, sections: SectionsMap, sectionName: string): IndexSignature {
+    _convertIndexSignature(entity: TypeDocNode, sections: SectionsMap, sectionName: string,
+                           subPackageName: string): IndexSignature {
         const key = entity.parameters[0];
         const indexSignature = {
             keyName: key.name,
-            keyType: typeDocUtils._convertType(key.type, sections, sectionName),
+            keyType: typeDocUtils._convertType(key.type, sections, sectionName, subPackageName),
             valueName: entity.type.name,
         };
         return indexSignature;
     },
-    _convertProperty(entity: TypeDocNode, sections: SectionsMap, sectionName: string): Property {
+    _convertProperty(entity: TypeDocNode, sections: SectionsMap, sectionName: string,
+                     subPackageName: string): Property {
         const source = entity.sources[0];
         const commentIfExists = !_.isUndefined(entity.comment) ? entity.comment.shortText : undefined;
         const property = {
             name: entity.name,
-            type: typeDocUtils._convertType(entity.type, sections, sectionName),
+            type: typeDocUtils._convertType(entity.type, sections, sectionName, subPackageName),
             source: {
                 fileName: source.fileName,
                 line: source.line,
@@ -207,28 +212,35 @@ export const typeDocUtils = {
         return property;
     },
     _convertMethod(
-        entity: TypeDocNode, isConstructor: boolean, sections: SectionsMap, sectionName: string,
+        entity: TypeDocNode, isConstructor: boolean, sections: SectionsMap, sectionName: string, subPackageName: string,
     ): TypescriptMethod {
         const signature = entity.signatures[0];
         const source = entity.sources[0];
         const hasComment = !_.isUndefined(signature.comment);
         const isStatic = _.isUndefined(entity.flags.isStatic) ? false : entity.flags.isStatic;
 
-        const topLevelInterface = isStatic ? 'ZeroEx.' : 'zeroEx.';
         // HACK: we use the fact that the sectionName is the same as the property name at the top-level
         // of the public interface. In the future, we shouldn't use this hack but rather get it from the JSON.
-        let callPath = (!_.isUndefined(sections.zeroEx) && sectionName !== sections.zeroEx) ?
-            `${topLevelInterface}${sectionName}.` :
-            topLevelInterface;
-        callPath = isConstructor || entity.name === '__type' ? '' : callPath;
+        let callPath;
+        if (isConstructor || entity.name === '__type') {
+            callPath = '';
+        } else if (subPackageName === '0x.js') {
+            const topLevelInterface = isStatic ? 'ZeroEx.' : 'zeroEx.';
+            callPath = (!_.isUndefined(sections.zeroEx) && sectionName !== sections.zeroEx) ?
+                       `${topLevelInterface}${sectionName}.` :
+                       topLevelInterface;
+        } else {
+            callPath = `${sectionName}.`;
+        }
 
         const parameters = _.map(signature.parameters, param => {
-            return typeDocUtils._convertParameter(param, sections, sectionName);
+            return typeDocUtils._convertParameter(param, sections, sectionName, subPackageName);
         });
-        const returnType = typeDocUtils._convertType(signature.type, sections, sectionName);
+        const returnType = typeDocUtils._convertType(signature.type, sections, sectionName, subPackageName);
         const typeParameter = _.isUndefined(signature.typeParameter) ?
                               undefined :
-                              typeDocUtils._convertTypeParameter(signature.typeParameter[0], sections, sectionName);
+                              typeDocUtils._convertTypeParameter(
+                                  signature.typeParameter[0], sections, sectionName, subPackageName);
 
         const method = {
             isConstructor,
@@ -247,15 +259,17 @@ export const typeDocUtils = {
         };
         return method;
     },
-    _convertTypeParameter(entity: TypeDocNode, sections: SectionsMap, sectionName: string): TypeParameter {
-        const type = typeDocUtils._convertType(entity.type, sections, sectionName);
+    _convertTypeParameter(entity: TypeDocNode, sections: SectionsMap, sectionName: string,
+                          subPackageName: string): TypeParameter {
+        const type = typeDocUtils._convertType(entity.type, sections, sectionName, subPackageName);
         const parameter = {
             name: entity.name,
             type,
         };
         return parameter;
     },
-    _convertParameter(entity: TypeDocNode, sections: SectionsMap, sectionName: string): Parameter {
+    _convertParameter(entity: TypeDocNode, sections: SectionsMap, sectionName: string,
+                      subPackageName: string): Parameter {
         let comment = '<No comment>';
         if (entity.comment && entity.comment.shortText) {
             comment = entity.comment.shortText;
@@ -267,7 +281,7 @@ export const typeDocUtils = {
             entity.flags.isOptional :
             false;
 
-        const type = typeDocUtils._convertType(entity.type, sections, sectionName);
+        const type = typeDocUtils._convertType(entity.type, sections, sectionName, subPackageName);
 
         const parameter = {
             name: entity.name,
@@ -277,17 +291,17 @@ export const typeDocUtils = {
         };
         return parameter;
     },
-    _convertType(entity: TypeDocType, sections: SectionsMap, sectionName: string): Type {
+    _convertType(entity: TypeDocType, sections: SectionsMap, sectionName: string, subPackageName: string): Type {
         const typeArguments = _.map(entity.typeArguments, typeArgument => {
-            return typeDocUtils._convertType(typeArgument, sections, sectionName);
+            return typeDocUtils._convertType(typeArgument, sections, sectionName, subPackageName);
         });
         const types = _.map(entity.types, t => {
-            return typeDocUtils._convertType(t, sections, sectionName);
+            return typeDocUtils._convertType(t, sections, sectionName, subPackageName);
         });
 
         const isConstructor = false;
         const methodIfExists = !_.isUndefined(entity.declaration) ?
-            typeDocUtils._convertMethod(entity.declaration, isConstructor, sections, sectionName) :
+            typeDocUtils._convertMethod(entity.declaration, isConstructor, sections, sectionName, subPackageName) :
             undefined;
 
         const elementTypeIfExists = !_.isUndefined(entity.elementType) ?


### PR DESCRIPTION
…call path

This PR:
* This fixes an issue where in the connect docs, functions would be displayed with a zeroEx instance name: ex. `zeroEx.getTokenPairs()` instead of `httpClient.getTokenPairs()`
