### PR TITLE
Implement first custom linter rule async-suffix

### DIFF
--- a/packages/dev-utils/src/blockchain_lifecycle.ts
+++ b/packages/dev-utils/src/blockchain_lifecycle.ts
@@ -20,7 +20,4 @@ export class BlockchainLifecycle {
             throw new Error(`Snapshot with id #${snapshotId} failed to revert`);
         }
     }
-    public async mineABlock(): Promise<void> {
-        await this.rpc.mineBlockAsync();
-    }
 }

--- a/packages/subproviders/src/globals.d.ts
+++ b/packages/subproviders/src/globals.d.ts
@@ -5,6 +5,7 @@ declare module 'es6-promisify';
 
 // tslint:disable:max-classes-per-file
 // tslint:disable:class-name
+// tslint:disable:async-suffix
 // tslint:disable:completed-docs
 
 // Ethereumjs-tx declarations

--- a/packages/subproviders/src/subproviders/redundant_rpc.ts
+++ b/packages/subproviders/src/subproviders/redundant_rpc.ts
@@ -33,6 +33,7 @@ export class RedundantRPCSubprovider extends Subprovider {
             });
         });
     }
+    // tslint:disable-next-line:async-suffix
     public async handleRequest(payload: JSONRPCPayload, next: () => void,
                                end: (err: Error|null, data?: any) =>  void): Promise<void> {
         const rpcsCopy = this.rpcs.slice();

--- a/packages/tslint-config/package.json
+++ b/packages/tslint-config/package.json
@@ -3,6 +3,11 @@
   "version": "0.2.1",
   "description": "Lint rules related to 0xProject for TSLint",
   "main": "tslint.json",
+  "scripts": {
+      "build": "tsc",
+      "clean": "shx rm -rf lib",
+      "lint": "tslint --project . 'rules/**/*.ts'"
+  },
   "files": [
     "tslint.js",
     "README.md",
@@ -29,10 +34,13 @@
   },
   "homepage": "https://github.com/0xProject/0x.js/packages/tslint-config/README.md",
   "devDependencies": {
+    "@types/lodash": "^4.14.86",
+    "shx": "^0.2.2",
     "tslint": "5.8.0",
     "typescript": "~2.6.1"
   },
   "dependencies": {
+    "lodash": "^4.17.4",
     "tslint-react": "^3.2.0"
   }
 }

--- a/packages/tslint-config/rules/asyncSuffixRule.ts
+++ b/packages/tslint-config/rules/asyncSuffixRule.ts
@@ -1,0 +1,10 @@
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+import {AsyncSuffixWalker} from './walkers/async_suffix';
+
+export class Rule extends Lint.Rules.AbstractRule {
+    public apply(sourceFile: ts.SourceFile): Lint.RuleFailure[] {
+        return this.applyWithWalker(new AsyncSuffixWalker(sourceFile, this.getOptions()));
+    }
+}

--- a/packages/tslint-config/rules/walkers/async_suffix.ts
+++ b/packages/tslint-config/rules/walkers/async_suffix.ts
@@ -1,0 +1,23 @@
+import * as _ from 'lodash';
+import * as Lint from 'tslint';
+import * as ts from 'typescript';
+
+export class AsyncSuffixWalker extends Lint.RuleWalker {
+    public static FAILURE_STRING = 'async functions must have an Async suffix';
+    public visitMethodDeclaration(node: ts.MethodDeclaration): void {
+        const methodNameNode = node.name;
+        const methodName = methodNameNode.getText();
+        if (!_.isUndefined(node.type)) {
+            if (node.type.kind === ts.SyntaxKind.TypeReference) {
+                const returnTypeName = (node.type as ts.TypeReferenceNode).typeName.getText();
+                if (returnTypeName === 'Promise' && !methodName.endsWith('Async')) {
+                    const failure = this.createFailure(
+                        methodNameNode.getStart(), methodNameNode.getWidth(), AsyncSuffixWalker.FAILURE_STRING,
+                    );
+                    this.addFailure(failure);
+                }
+            }
+        }
+        super.visitMethodDeclaration(node);
+    }
+}

--- a/packages/tslint-config/tsconfig.json
+++ b/packages/tslint-config/tsconfig.json
@@ -1,0 +1,15 @@
+{
+  "compilerOptions": {
+    "module": "commonjs",
+    "target": "es5",
+    "lib": [ "es2017", "dom"],
+    "outDir": "lib",
+    "sourceMap": true,
+    "declaration": true,
+    "noImplicitAny": true,
+    "strictNullChecks": true
+  },
+  "include": [
+    "./rules/**/*"
+  ]
+}

--- a/packages/tslint-config/tslint.json
+++ b/packages/tslint-config/tslint.json
@@ -7,6 +7,7 @@
     "adjacent-overload-signatures": true,
     "arrow-parens": [true, "ban-single-arg-parens"],
     "arrow-return-shorthand": true,
+    "async-suffix": true,
     "await-promise": true,
     "binary-expression-operand-order": true,
     "callable-types": true,
@@ -101,5 +102,6 @@
     "jsx-self-close": true,
     "jsx-wrap-multiline": false,
     "jsx-no-bind": false
-  }
+  },
+  "rulesDirectory": "lib"
 }


### PR DESCRIPTION
This PR:
* Implements first custom linter rule that checks that every function returning a promise has an `Async` suffix
