### PR TITLE
Refactor EtherToken wrapper to accept address in method args

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+v0.28.0 - _TBD_
+------------------------
+* Add `etherTokenAddress` arg to `depositAsync` and `withdrawAsync` methods on `EtherToken` wrapper. (#267)
+
 v0.27.1 - _November 28, 2017_
 ------------------------
     * Export `TransactionOpts` type

--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -2,7 +2,9 @@
 
 v0.28.0 - _TBD_
 ------------------------
-* Add `etherTokenAddress` arg to `depositAsync` and `withdrawAsync` methods on `EtherToken` wrapper. (#267)
+* Add `etherTokenAddress` arg to `depositAsync` and `withdrawAsync` methods on `zeroEx.etherToken` (#267)
+* Removed accidentally included `unsubscribeAll` method from `zeroEx.proxy`, `zeroEx.etherToken` and `zeroEx.tokenRegistry` (#267)
+* Removed `etherTokenContractAddress` from `ZeroEx` constructor arg `ZeroExConfig` (#267)
 
 v0.27.1 - _November 28, 2017_
 ------------------------

--- a/packages/0x.js/src/0x.ts
+++ b/packages/0x.js/src/0x.ts
@@ -199,7 +199,7 @@ export class ZeroEx {
             this._web3Wrapper, config.networkId, config.tokenRegistryContractAddress,
         );
         this.etherToken = new EtherTokenWrapper(
-            this._web3Wrapper, config.networkId, this.token, config.etherTokenContractAddress,
+            this._web3Wrapper, config.networkId, this.token,
         );
         this.orderStateWatcher = new OrderStateWatcher(
             this._web3Wrapper, this._abiDecoder, this.token, this.exchange, config.orderWatcherConfig,

--- a/packages/0x.js/src/contract_wrappers/contract_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/contract_wrapper.ts
@@ -50,10 +50,7 @@ export class ContractWrapper {
         this._onLogAddedSubscriptionToken = undefined;
         this._onLogRemovedSubscriptionToken = undefined;
     }
-    /**
-     * Cancels all existing subscriptions
-     */
-    public unsubscribeAll(): void {
+    protected unsubscribeAll(): void {
         const filterTokens = _.keys(this._filterCallbacks);
         _.each(filterTokens, filterToken => {
             this._unsubscribe(filterToken);

--- a/packages/0x.js/src/contract_wrappers/ether_token_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/ether_token_wrapper.ts
@@ -17,24 +17,22 @@ import {TokenWrapper} from './token_wrapper';
 export class EtherTokenWrapper extends ContractWrapper {
     private _etherTokenContractIfExists?: EtherTokenContract;
     private _tokenWrapper: TokenWrapper;
-    private _contractAddressIfExists?: string;
-    constructor(web3Wrapper: Web3Wrapper, networkId: number, tokenWrapper: TokenWrapper,
-                contractAddressIfExists?: string) {
+    constructor(web3Wrapper: Web3Wrapper, networkId: number, tokenWrapper: TokenWrapper) {
         super(web3Wrapper, networkId);
         this._tokenWrapper = tokenWrapper;
-        this._contractAddressIfExists = contractAddressIfExists;
     }
     /**
      * Deposit ETH into the Wrapped ETH smart contract and issues the equivalent number of wrapped ETH tokens
      * to the depositor address. These wrapped ETH tokens can be used in 0x trades and are redeemable for 1-to-1
      * for ETH.
-     * @param   amountInWei      Amount of ETH in Wei the caller wishes to deposit.
-     * @param   depositor        The hex encoded user Ethereum address that would like to make the deposit.
-     * @param   txOpts           Transaction parameters.
+     * @param   etherTokenAddress   EtherToken address you wish to deposit into.
+     * @param   amountInWei         Amount of ETH in Wei the caller wishes to deposit.
+     * @param   depositor           The hex encoded user Ethereum address that would like to make the deposit.
+     * @param   txOpts              Transaction parameters.
      * @return Transaction hash.
      */
     public async depositAsync(
-        amountInWei: BigNumber, depositor: string, txOpts: TransactionOpts = {},
+        etherTokenAddress: string, amountInWei: BigNumber, depositor: string, txOpts: TransactionOpts = {},
     ): Promise<string> {
         assert.isValidBaseUnitAmount('amountInWei', amountInWei);
         await assert.isSenderAddressAsync('depositor', depositor, this._web3Wrapper);
@@ -42,7 +40,7 @@ export class EtherTokenWrapper extends ContractWrapper {
         const ethBalanceInWei = await this._web3Wrapper.getBalanceInWeiAsync(depositor);
         assert.assert(ethBalanceInWei.gte(amountInWei), ZeroExError.InsufficientEthBalanceForDeposit);
 
-        const wethContract = await this._getEtherTokenContractAsync();
+        const wethContract = await this._getEtherTokenContractAsync(etherTokenAddress);
         const txHash = await wethContract.deposit.sendTransactionAsync({
             from: depositor,
             value: amountInWei,
@@ -54,22 +52,22 @@ export class EtherTokenWrapper extends ContractWrapper {
     /**
      * Withdraw ETH to the withdrawer's address from the wrapped ETH smart contract in exchange for the
      * equivalent number of wrapped ETH tokens.
+     * @param   etherTokenAddress   EtherToken address you wish to withdraw from.
      * @param   amountInWei  Amount of ETH in Wei the caller wishes to withdraw.
      * @param   withdrawer   The hex encoded user Ethereum address that would like to make the withdrawl.
      * @param   txOpts       Transaction parameters.
      * @return Transaction hash.
      */
     public async withdrawAsync(
-        amountInWei: BigNumber, withdrawer: string, txOpts: TransactionOpts = {},
+        etherTokenAddress: string, amountInWei: BigNumber, withdrawer: string, txOpts: TransactionOpts = {},
     ): Promise<string> {
         assert.isValidBaseUnitAmount('amountInWei', amountInWei);
         await assert.isSenderAddressAsync('withdrawer', withdrawer, this._web3Wrapper);
 
-        const wethContractAddress = this.getContractAddress();
-        const WETHBalanceInBaseUnits = await this._tokenWrapper.getBalanceAsync(wethContractAddress, withdrawer);
+        const WETHBalanceInBaseUnits = await this._tokenWrapper.getBalanceAsync(etherTokenAddress, withdrawer);
         assert.assert(WETHBalanceInBaseUnits.gte(amountInWei), ZeroExError.InsufficientWEthBalanceForWithdrawal);
 
-        const wethContract = await this._getEtherTokenContractAsync();
+        const wethContract = await this._getEtherTokenContractAsync(etherTokenAddress);
         const txHash = await wethContract.withdraw.sendTransactionAsync(amountInWei, {
             from: withdrawer,
             gas: txOpts.gasLimit,
@@ -77,25 +75,12 @@ export class EtherTokenWrapper extends ContractWrapper {
         });
         return txHash;
     }
-    /**
-     * Retrieves the Wrapped Ether token contract address
-     * @return  The Wrapped Ether token contract address
-     */
-    public getContractAddress(): string {
-        const contractAddress = this._getContractAddress(
-            artifacts.EtherTokenArtifact, this._contractAddressIfExists,
-        );
-        return contractAddress;
-    }
     private _invalidateContractInstance(): void {
         delete this._etherTokenContractIfExists;
     }
-    private async _getEtherTokenContractAsync(): Promise<EtherTokenContract> {
-        if (!_.isUndefined(this._etherTokenContractIfExists)) {
-            return this._etherTokenContractIfExists;
-        }
+    private async _getEtherTokenContractAsync(etherTokenAddress: string): Promise<EtherTokenContract> {
         const web3ContractInstance = await this._instantiateContractIfExistsAsync(
-            artifacts.EtherTokenArtifact, this._contractAddressIfExists,
+            artifacts.EtherTokenArtifact, etherTokenAddress,
         );
         const contractInstance = new EtherTokenContract(web3ContractInstance, this._web3Wrapper.getContractDefaults());
         this._etherTokenContractIfExists = contractInstance;

--- a/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
@@ -608,6 +608,12 @@ export class ExchangeWrapper extends ContractWrapper {
         this._unsubscribe(subscriptionToken);
     }
     /**
+     * Cancels all existing subscriptions
+     */
+    public unsubscribeAll(): void {
+        super.unsubscribeAll();
+    }
+    /**
      * Gets historical logs without creating a subscription
      * @param   eventName           The exchange contract event you would like to subscribe to.
      * @param   subscriptionOpts    Subscriptions options that let you configure the subscription.

--- a/packages/0x.js/src/contract_wrappers/token_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/token_wrapper.ts
@@ -282,6 +282,12 @@ export class TokenWrapper extends ContractWrapper {
         this._unsubscribe(subscriptionToken);
     }
     /**
+     * Cancels all existing subscriptions
+     */
+    public unsubscribeAll(): void {
+        super.unsubscribeAll();
+    }
+    /**
      * Gets historical logs without creating a subscription
      * @param   tokenAddress        An address of the token that emmited the logs.
      * @param   eventName           The token contract event you would like to subscribe to.

--- a/packages/0x.js/src/schemas/zero_ex_config_schema.ts
+++ b/packages/0x.js/src/schemas/zero_ex_config_schema.ts
@@ -8,7 +8,6 @@ export const zeroExConfigSchema = {
         gasPrice: {$ref: '/Number'},
         exchangeContractAddress: {$ref: '/Address'},
         tokenRegistryContractAddress: {$ref: '/Address'},
-        etherTokenContractAddress: {$ref: '/Address'},
         orderWatcherConfig: {
             type: 'object',
             properties: {

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -268,7 +268,6 @@ export interface OrderStateWatcherConfig {
  * gasPrice: Gas price to use with every transaction
  * exchangeContractAddress: The address of an exchange contract to use
  * tokenRegistryContractAddress: The address of a token registry contract to use
- * etherTokenContractAddress: The address of an ether token contract to use
  * tokenTransferProxyContractAddress: The address of the token transfer proxy contract to use
  * orderWatcherConfig: All the configs related to the orderWatcher
  */
@@ -277,7 +276,6 @@ export interface ZeroExConfig {
     gasPrice?: BigNumber;
     exchangeContractAddress?: string;
     tokenRegistryContractAddress?: string;
-    etherTokenContractAddress?: string;
     tokenTransferProxyContractAddress?: string;
     orderWatcherConfig?: OrderStateWatcherConfig;
 }

--- a/packages/0x.js/test/0x.js_test.ts
+++ b/packages/0x.js/test/0x.js_test.ts
@@ -244,14 +244,6 @@ describe('ZeroEx library', () => {
             const zeroExWithWrongExchangeAddress = new ZeroEx(web3.currentProvider, zeroExConfig);
             expect(zeroExWithWrongExchangeAddress.exchange.getContractAddress()).to.be.equal(ZeroEx.NULL_ADDRESS);
         });
-        it('allows to specify ether token contract address', async () => {
-            const zeroExConfig = {
-                etherTokenContractAddress: ZeroEx.NULL_ADDRESS,
-                networkId: constants.TESTRPC_NETWORK_ID,
-            };
-            const zeroExWithWrongEtherTokenAddress = new ZeroEx(web3.currentProvider, zeroExConfig);
-            expect(zeroExWithWrongEtherTokenAddress.etherToken.getContractAddress()).to.be.equal(ZeroEx.NULL_ADDRESS);
-        });
         it('allows to specify token registry token contract address', async () => {
             const zeroExConfig = {
                 tokenRegistryContractAddress: ZeroEx.NULL_ADDRESS,

--- a/packages/contracts/test/ts/ether_token.ts
+++ b/packages/contracts/test/ts/ether_token.ts
@@ -28,7 +28,6 @@ contract('EtherToken', (accounts: string[]) => {
         etherTokenAddress = EtherToken.address;
         zeroEx = new ZeroEx(web3.currentProvider, {
             gasPrice,
-            etherTokenContractAddress: etherTokenAddress,
             networkId: constants.TESTRPC_NETWORK_ID,
         });
     });
@@ -45,7 +44,7 @@ contract('EtherToken', (accounts: string[]) => {
             const initEthBalance = await getEthBalanceAsync(account);
             const ethToDeposit = initEthBalance.plus(1);
 
-            return expect(zeroEx.etherToken.depositAsync(ethToDeposit, account))
+            return expect(zeroEx.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account))
                 .to.be.rejectedWith(ZeroExError.InsufficientEthBalanceForDeposit);
         });
 
@@ -55,7 +54,7 @@ contract('EtherToken', (accounts: string[]) => {
 
             const ethToDeposit = new BigNumber(web3.toWei(1, 'ether'));
 
-            const txHash = await zeroEx.etherToken.depositAsync(ethToDeposit, account);
+            const txHash = await zeroEx.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account);
             const receipt = await zeroEx.awaitTransactionMinedAsync(txHash);
 
             const ethSpentOnGas = gasPrice.times(receipt.gasUsed);
@@ -72,7 +71,7 @@ contract('EtherToken', (accounts: string[]) => {
             const initEthTokenBalance = await zeroEx.token.getBalanceAsync(etherTokenAddress, account);
             const ethTokensToWithdraw = initEthTokenBalance.plus(1);
 
-            return expect(zeroEx.etherToken.withdrawAsync(ethTokensToWithdraw, account))
+            return expect(zeroEx.etherToken.withdrawAsync(etherTokenAddress, ethTokensToWithdraw, account))
                 .to.be.rejectedWith(ZeroExError.InsufficientWEthBalanceForWithdrawal);
         });
 
@@ -81,7 +80,7 @@ contract('EtherToken', (accounts: string[]) => {
             const initEthBalance = await getEthBalanceAsync(account);
             const ethTokensToWithdraw = initEthTokenBalance;
             expect(ethTokensToWithdraw).to.not.be.bignumber.equal(0);
-            const txHash = await zeroEx.etherToken.withdrawAsync(ethTokensToWithdraw, account, {
+            const txHash = await zeroEx.etherToken.withdrawAsync(etherTokenAddress, ethTokensToWithdraw, account, {
                 gasLimit: constants.MAX_ETHERTOKEN_WITHDRAW_GAS,
             });
             const receipt = await zeroEx.awaitTransactionMinedAsync(txHash);

--- a/packages/contracts/test/ts/ether_token_v2.ts
+++ b/packages/contracts/test/ts/ether_token_v2.ts
@@ -28,7 +28,6 @@ contract('EtherTokenV2', (accounts: string[]) => {
         etherTokenAddress = etherToken.address;
         zeroEx = new ZeroEx(web3.currentProvider, {
             gasPrice,
-            etherTokenContractAddress: etherTokenAddress,
             networkId: constants.TESTRPC_NETWORK_ID,
         });
     });
@@ -45,7 +44,7 @@ contract('EtherTokenV2', (accounts: string[]) => {
             const initEthBalance = await getEthBalanceAsync(account);
             const ethToDeposit = initEthBalance.plus(1);
 
-            return expect(zeroEx.etherToken.depositAsync(ethToDeposit, account))
+            return expect(zeroEx.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account))
                 .to.be.rejectedWith(ZeroExError.InsufficientEthBalanceForDeposit);
         });
 
@@ -55,7 +54,7 @@ contract('EtherTokenV2', (accounts: string[]) => {
 
             const ethToDeposit = new BigNumber(web3.toWei(1, 'ether'));
 
-            const txHash = await zeroEx.etherToken.depositAsync(ethToDeposit, account);
+            const txHash = await zeroEx.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account);
             const receipt = await zeroEx.awaitTransactionMinedAsync(txHash);
 
             const ethSpentOnGas = gasPrice.times(receipt.gasUsed);
@@ -69,7 +68,7 @@ contract('EtherTokenV2', (accounts: string[]) => {
         it('should log 1 event with correct arguments', async () => {
             const ethToDeposit = new BigNumber(web3.toWei(1, 'ether'));
 
-            const txHash = await zeroEx.etherToken.depositAsync(ethToDeposit, account);
+            const txHash = await zeroEx.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account);
             const receipt = await zeroEx.awaitTransactionMinedAsync(txHash);
 
             const logs = receipt.logs;
@@ -88,14 +87,14 @@ contract('EtherTokenV2', (accounts: string[]) => {
     describe('withdraw', () => {
         beforeEach(async () => {
             const ethToDeposit = new BigNumber(web3.toWei(1, 'ether'));
-            await zeroEx.etherToken.depositAsync(ethToDeposit, account);
+            await zeroEx.etherToken.depositAsync(etherTokenAddress, ethToDeposit, account);
         });
 
         it('should throw if caller attempts to withdraw greater than caller balance', async () => {
             const initEthTokenBalance = await zeroEx.token.getBalanceAsync(etherTokenAddress, account);
             const ethTokensToWithdraw = initEthTokenBalance.plus(1);
 
-            return expect(zeroEx.etherToken.withdrawAsync(ethTokensToWithdraw, account))
+            return expect(zeroEx.etherToken.withdrawAsync(etherTokenAddress, ethTokensToWithdraw, account))
                 .to.be.rejectedWith(ZeroExError.InsufficientWEthBalanceForWithdrawal);
         });
 
@@ -104,7 +103,7 @@ contract('EtherTokenV2', (accounts: string[]) => {
             const initEthBalance = await getEthBalanceAsync(account);
             const ethTokensToWithdraw = initEthTokenBalance;
             expect(ethTokensToWithdraw).to.not.be.bignumber.equal(0);
-            const txHash = await zeroEx.etherToken.withdrawAsync(ethTokensToWithdraw, account, {
+            const txHash = await zeroEx.etherToken.withdrawAsync(etherTokenAddress, ethTokensToWithdraw, account, {
                 gasLimit: constants.MAX_ETHERTOKEN_WITHDRAW_GAS,
             });
             const receipt = await zeroEx.awaitTransactionMinedAsync(txHash);
@@ -122,7 +121,7 @@ contract('EtherTokenV2', (accounts: string[]) => {
             const initEthTokenBalance = await zeroEx.token.getBalanceAsync(etherTokenAddress, account);
             const ethTokensToWithdraw = initEthTokenBalance;
             expect(ethTokensToWithdraw).to.not.be.bignumber.equal(0);
-            const txHash = await zeroEx.etherToken.withdrawAsync(ethTokensToWithdraw, account, {
+            const txHash = await zeroEx.etherToken.withdrawAsync(etherTokenAddress, ethTokensToWithdraw, account, {
                 gasLimit: constants.MAX_ETHERTOKEN_WITHDRAW_GAS,
             });
             const receipt = await zeroEx.awaitTransactionMinedAsync(txHash);

--- a/packages/website/ts/blockchain.ts
+++ b/packages/website/ts/blockchain.ts
@@ -388,18 +388,18 @@ export class Blockchain {
         const balance = await this.web3Wrapper.getBalanceInEthAsync(owner);
         return balance;
     }
-    public async convertEthToWrappedEthTokensAsync(amount: BigNumber): Promise<void> {
+    public async convertEthToWrappedEthTokensAsync(etherTokenAddress: string, amount: BigNumber): Promise<void> {
         utils.assert(!_.isUndefined(this.zeroEx), 'ZeroEx must be instantiated.');
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
-        const txHash = await this.zeroEx.etherToken.depositAsync(amount, this.userAddress);
+        const txHash = await this.zeroEx.etherToken.depositAsync(etherTokenAddress, amount, this.userAddress);
         await this.showEtherScanLinkAndAwaitTransactionMinedAsync(txHash);
     }
-    public async convertWrappedEthTokensToEthAsync(amount: BigNumber): Promise<void> {
+    public async convertWrappedEthTokensToEthAsync(etherTokenAddress: string, amount: BigNumber): Promise<void> {
         utils.assert(!_.isUndefined(this.zeroEx), 'ZeroEx must be instantiated.');
         utils.assert(this.doesUserAddressExist(), BlockchainCallErrs.USER_HAS_NO_ASSOCIATED_ADDRESSES);
 
-        const txHash = await this.zeroEx.etherToken.withdrawAsync(amount, this.userAddress);
+        const txHash = await this.zeroEx.etherToken.withdrawAsync(etherTokenAddress, amount, this.userAddress);
         await this.showEtherScanLinkAndAwaitTransactionMinedAsync(txHash);
     }
     public async doesContractExistAtAddressAsync(address: string) {

--- a/packages/website/ts/components/eth_weth_conversion_button.tsx
+++ b/packages/website/ts/components/eth_weth_conversion_button.tsx
@@ -88,12 +88,12 @@ export class EthWethConversionButton extends
         let balance = tokenState.balance;
         try {
             if (direction === Side.deposit) {
-                await this.props.blockchain.convertEthToWrappedEthTokensAsync(value);
+                await this.props.blockchain.convertEthToWrappedEthTokensAsync(token.address, value);
                 const ethAmount = ZeroEx.toUnitAmount(value, constants.ETH_DECIMAL_PLACES);
                 this.props.dispatcher.showFlashMessage(`Successfully wrapped ${ethAmount.toString()} ETH to WETH`);
                 balance = balance.plus(value);
             } else {
-                await this.props.blockchain.convertWrappedEthTokensToEthAsync(value);
+                await this.props.blockchain.convertWrappedEthTokensToEthAsync(token.address, value);
                 const tokenAmount = ZeroEx.toUnitAmount(value, token.decimals);
                 this.props.dispatcher.showFlashMessage(`Successfully unwrapped ${tokenAmount.toString()} WETH to ETH`);
                 balance = balance.minus(value);


### PR DESCRIPTION
This PR:
- Modifies the `etherTokenWrapper` methods to accept an `etherTokenAddress` as the first arg. Since it is becoming apparent we will be updating the canonical WETH contract, we want users of 0x.js to be able to interact with n number of etherToken contracts without re-instantiating the library for each one. Because of this, we modify the interface for `etherTokenWrapper` methods to be similar to `tokenWrapper` methods.
- Unrelated: I also fixed an issue with 0x.js docs where `unsubscribeAll` was showing up as a method in each contractWrapper instance since it was declared in the base class. Since it is only used by `exchangeWrapper` and `tokenWrapper`, I made it `protected` and re-declared it in those two.
