### PR TITLE
Fix code selection bug in docs

### DIFF
--- a/package.json
+++ b/package.json
@@ -7,6 +7,7 @@
     "scripts": {
         "testrpc": "testrpc -p 8545 --networkId 50 -m \"${npm_package_config_mnemonic}\"",
         "lerna:run": "lerna run",
+        "lerna:rebuild": "lerna run clean; lerna run build;",
         "lerna:publish": "yarn install; lerna run clean; lerna run build; lerna publish --registry=https://registry.npmjs.org/"
     },
     "config": {

--- a/packages/website/ts/pages/shared/markdown_code_block.tsx
+++ b/packages/website/ts/pages/shared/markdown_code_block.tsx
@@ -7,14 +7,23 @@ interface MarkdownCodeBlockProps {
     language: string;
 }
 
-export function MarkdownCodeBlock(props: MarkdownCodeBlockProps) {
-    return (
-        <span style={{fontSize: 16}}>
-            <HighLight
-                className={props.language || 'js'}
-            >
-                {props.literal}
-            </HighLight>
-        </span>
-    );
+interface MarkdownCodeBlockState {}
+
+export class MarkdownCodeBlock extends React.Component<MarkdownCodeBlockProps, MarkdownCodeBlockState> {
+    // Re-rendering a codeblock causes any use selection to become de-selected. This is annoying when trying
+    // to copy-paste code examples. We therefore noop re-renders on this component if it's props haven't changed.
+    public shouldComponentUpdate(nextProps: MarkdownCodeBlockProps, nextState: MarkdownCodeBlockState) {
+        return nextProps.literal !== this.props.literal || nextProps.language !== this.props.language;
+    }
+    public render() {
+        return (
+            <span style={{fontSize: 16}}>
+                <HighLight
+                    className={this.props.language || 'javascript'}
+                >
+                    {this.props.literal}
+                </HighLight>
+            </span>
+        );
+    }
 }


### PR DESCRIPTION
This PR:
* Fixes https://github.com/0xProject/wiki/issues/19
* Disables re-rendering markdownCodeBlock renderer if props haven't changed. Re-rendering this component causes a user's selection to become de-selected. This is annoying while trying to copy-paste code examples from wiki, 0x.js docs, etc...
* Adds a convenience `yarn lerna:rebuild` command that first calls `clean` followed by `build`.