### PR TITLE
Move web3 import after subprovider imports in test web3_factory

### DIFF
--- a/packages/0x.js/test/0x.js_test.ts
+++ b/packages/0x.js/test/0x.js_test.ts
@@ -82,9 +82,9 @@ describe('ZeroEx library', () => {
         it('should return true if the signature does pertain to the dataHex & address', async () => {
             const isValidSignatureLocal = ZeroEx.isValidSignature(dataHex, signature, address);
             expect(isValidSignatureLocal).to.be.true();
-            const isValidSignatureOnContract = await (zeroEx.exchange as any)
-                ._isValidSignatureUsingContractCallAsync(dataHex, signature, address);
-            return expect(isValidSignatureOnContract).to.be.true();
+            return expect(
+                (zeroEx.exchange as any)._isValidSignatureUsingContractCallAsync(dataHex, signature, address),
+            ).to.become(true);
         });
     });
     describe('#generateSalt', () => {

--- a/packages/0x.js/test/utils/web3_factory.ts
+++ b/packages/0x.js/test/utils/web3_factory.ts
@@ -3,7 +3,6 @@
 // we are not running in a browser env.
 // Filed issue: https://github.com/ethereum/web3.js/issues/844
 (global as any).XMLHttpRequest = undefined;
-import * as Web3 from 'web3';
 import ProviderEngine = require('web3-provider-engine');
 import RpcSubprovider = require('web3-provider-engine/subproviders/rpc');
 
@@ -11,6 +10,13 @@ import {EmptyWalletSubprovider} from './subproviders/empty_wallet_subprovider';
 import {FakeGasEstimateSubprovider} from './subproviders/fake_gas_estimate_subprovider';
 
 import {constants} from './constants';
+
+// HACK: web3 leaks XMLHttpRequest into the global scope and causes requests to hang
+// because they are using the wrong XHR package.
+// importing web3 after subproviders fixes this issue
+// Filed issue: https://github.com/ethereum/web3.js/issues/844
+// tslint:disable-next-line:ordered-imports
+import * as Web3 from 'web3';
 
 export const web3Factory = {
     create(hasAddresses: boolean = true): Web3 {

--- a/packages/kovan-faucets/src/ts/handler.ts
+++ b/packages/kovan-faucets/src/ts/handler.ts
@@ -13,7 +13,7 @@ import {ZRXRequestQueue} from './zrx_request_queue';
 
 // HACK: web3 leaks XMLHttpRequest into the global scope and causes requests to hang
 // because they are using the wrong XHR package.
-// Issue: https://github.com/trufflesuite/truffle-contract/issues/14
+// Filed issue: https://github.com/ethereum/web3.js/issues/844
 // tslint:disable-next-line:ordered-imports
 import * as Web3 from 'web3';
 

--- a/packages/kovan-faucets/src/ts/request_queue.ts
+++ b/packages/kovan-faucets/src/ts/request_queue.ts
@@ -3,7 +3,7 @@ import * as timers from 'timers';
 
 // HACK: web3 leaks XMLHttpRequest into the global scope and causes requests to hang
 // because they are using the wrong XHR package.
-// Issue: https://github.com/trufflesuite/truffle-contract/issues/14
+// Filed issue: https://github.com/ethereum/web3.js/issues/844
 // tslint:disable-next-line:ordered-imports
 import * as Web3 from 'web3';
 

--- a/packages/kovan-faucets/src/ts/zrx_request_queue.ts
+++ b/packages/kovan-faucets/src/ts/zrx_request_queue.ts
@@ -9,7 +9,7 @@ import {utils} from './utils';
 
 // HACK: web3 leaks XMLHttpRequest into the global scope and causes requests to hang
 // because they are using the wrong XHR package.
-// Issue: https://github.com/trufflesuite/truffle-contract/issues/14
+// Filed issue: https://github.com/ethereum/web3.js/issues/844
 // tslint:disable-next-line:ordered-imports
 import * as Web3 from 'web3';
 


### PR DESCRIPTION
This PR:
* Move web3 import after subprovider imports in order to fix hanging RPC requests
* Update a couple comments to reference the web3 issue
* Update a `isValidSignature` test in the 0x.js tests to be more consistent with the others
