### PR TITLE
Remove reliance on testrpc snapshot in ZRX tests

### DIFF
--- a/packages/contracts/test/ts/zrx_token.ts
+++ b/packages/contracts/test/ts/zrx_token.ts
@@ -29,8 +29,8 @@ contract('ZRXToken', (accounts: string[]) => {
             exchangeContractAddress: Exchange.address,
             networkId: constants.TESTRPC_NETWORK_ID,
         });
-        zrxAddress = zeroEx.exchange.getZRXTokenAddress();
-        zrx = await ZRXToken.at(zrxAddress);
+        zrx = await ZRXToken.new();
+        zrxAddress = zrx.address;
         MAX_UINT = zeroEx.token.UNLIMITED_ALLOWANCE_IN_BASE_UNITS;
     });
 
@@ -94,15 +94,12 @@ contract('ZRXToken', (accounts: string[]) => {
         it('should return false if owner has insufficient balance', async () => {
             const ownerBalance = await zeroEx.token.getBalanceAsync(zrxAddress, owner);
             const amountToTransfer = ownerBalance.plus(1);
-            let txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, amountToTransfer,
-                                                              {gasLimit: constants.MAX_TOKEN_APPROVE_GAS});
+            const txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, amountToTransfer, {
+                gasLimit: constants.MAX_TOKEN_APPROVE_GAS,
+            });
             await zeroEx.awaitTransactionMinedAsync(txHash);
             const didReturnTrue = await zrx.transferFrom.call(owner, spender, amountToTransfer, {from: spender});
             expect(didReturnTrue).to.be.false();
-            // Reset allowance
-            txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, new BigNumber(0),
-                                                          {gasLimit: constants.MAX_TOKEN_APPROVE_GAS});
-            await zeroEx.awaitTransactionMinedAsync(txHash);
         });
 
         it('should return false if spender has insufficient allowance', async () => {
@@ -127,17 +124,17 @@ contract('ZRXToken', (accounts: string[]) => {
             const initOwnerBalance = await zeroEx.token.getBalanceAsync(zrxAddress, owner);
             const amountToTransfer = initOwnerBalance;
             const initSpenderAllowance = MAX_UINT;
-            let txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, initSpenderAllowance);
+            let txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, initSpenderAllowance, {
+                gasLimit: constants.MAX_TOKEN_APPROVE_GAS,
+            });
             await zeroEx.awaitTransactionMinedAsync(txHash);
-            txHash = await zeroEx.token.transferFromAsync(zrxAddress, owner, spender, spender, amountToTransfer,
-                                                          {gasLimit: constants.MAX_TOKEN_TRANSFERFROM_GAS});
+            txHash = await zeroEx.token.transferFromAsync(zrxAddress, owner, spender, spender, amountToTransfer, {
+                gasLimit: constants.MAX_TOKEN_TRANSFERFROM_GAS,
+            });
             await zeroEx.awaitTransactionMinedAsync(txHash);
 
             const newSpenderAllowance = await zeroEx.token.getAllowanceAsync(zrxAddress, owner, spender);
             expect(initSpenderAllowance).to.be.bignumber.equal(newSpenderAllowance);
-            // Restore balance
-            txHash = await zeroEx.token.transferAsync(zrxAddress, spender, owner, amountToTransfer);
-            await zeroEx.awaitTransactionMinedAsync(txHash);
         });
 
         it('should transfer the correct balances if spender has sufficient allowance', async () => {
@@ -147,8 +144,9 @@ contract('ZRXToken', (accounts: string[]) => {
             const initSpenderAllowance = initOwnerBalance;
             let txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, initSpenderAllowance);
             await zeroEx.awaitTransactionMinedAsync(txHash);
-            txHash = await zeroEx.token.transferFromAsync(zrxAddress, owner, spender, spender, amountToTransfer,
-                                                          {gasLimit: constants.MAX_TOKEN_TRANSFERFROM_GAS});
+            txHash = await zeroEx.token.transferFromAsync(zrxAddress, owner, spender, spender, amountToTransfer, {
+                gasLimit: constants.MAX_TOKEN_TRANSFERFROM_GAS,
+            });
             await zeroEx.awaitTransactionMinedAsync(txHash);
 
             const newOwnerBalance = await zeroEx.token.getBalanceAsync(zrxAddress, owner);
@@ -161,11 +159,11 @@ contract('ZRXToken', (accounts: string[]) => {
         it('should modify allowance if spender has sufficient allowance less than 2^256 - 1', async () => {
             const initOwnerBalance = await zeroEx.token.getBalanceAsync(zrxAddress, owner);
             const amountToTransfer = initOwnerBalance;
-            const initSpenderAllowance = initOwnerBalance;
-            let txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, initSpenderAllowance);
+            let txHash = await zeroEx.token.setAllowanceAsync(zrxAddress, owner, spender, amountToTransfer);
             await zeroEx.awaitTransactionMinedAsync(txHash);
-            txHash = await zeroEx.token.transferFromAsync(zrxAddress, owner, spender, spender, amountToTransfer,
-                                                          {gasLimit: constants.MAX_TOKEN_TRANSFERFROM_GAS});
+            txHash = await zeroEx.token.transferFromAsync(zrxAddress, owner, spender, spender, amountToTransfer, {
+                gasLimit: constants.MAX_TOKEN_TRANSFERFROM_GAS,
+            });
             await zeroEx.awaitTransactionMinedAsync(txHash);
 
             const newSpenderAllowance = await zeroEx.token.getAllowanceAsync(zrxAddress, owner, spender);

--- a/yarn.lock
+++ b/yarn.lock
@@ -270,10 +270,6 @@
   version "10.0.0"
   resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-10.0.0.tgz#b93aa88155fe5106cddf3f934517411ca2a45939"
 
-"@types/yargs@^8.0.2":
-  version "8.0.2"
-  resolved "https://registry.yarnpkg.com/@types/yargs/-/yargs-8.0.2.tgz#0f9c7b236e2d78cd8f4b6502de15d0728aa29385"
-
 JSONStream@^1.0.4:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/JSONStream/-/JSONStream-1.3.1.tgz#707f761e01dae9e16f1bcf93703b78c70966579a"


### PR DESCRIPTION
This PR:
* Deploys a new `ZRXToken` before each test, rather than pulling the address from the 0x.js artifacts (this would be fine if contracts shared artifacts with 0x.js). None of the other contract tests rely on the snapshot, so this should be no different.
