### PR TITLE
Fix toBaseUnitAmount Issue

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -1,5 +1,10 @@
 # CHANGELOG
 
+vx.x.x - _TBD_
+------------------------
+    * Assert baseUnit amount supplied to `toUnitAmount` is integer amount. (#287)
+    * `toBaseUnitAmount` throws if amount supplied has too many decimals (#287)
+
 v0.28.0 - _December 20, 2017_
 ------------------------
     * Add `etherTokenAddress` arg to `depositAsync` and `withdrawAsync` methods on `zeroEx.etherToken` (#267)

--- a/packages/0x.js/src/0x.ts
+++ b/packages/0x.js/src/0x.ts
@@ -128,7 +128,7 @@ export class ZeroEx {
      * @return  The amount in units.
      */
     public static toUnitAmount(amount: BigNumber, decimals: number): BigNumber {
-        assert.isBigNumber('amount', amount);
+        assert.isValidBaseUnitAmount('amount', amount);
         assert.isNumber('decimals', decimals);
 
         const aUnit = new BigNumber(10).pow(decimals);

--- a/packages/0x.js/src/0x.ts
+++ b/packages/0x.js/src/0x.ts
@@ -149,6 +149,10 @@ export class ZeroEx {
 
         const unit = new BigNumber(10).pow(decimals);
         const baseUnitAmount = amount.times(unit);
+        const hasDecimals = baseUnitAmount.decimalPlaces() !== 0;
+        if (hasDecimals) {
+            throw new Error(`Invalid unit amount: ${amount.toString()} - Too many decimal places`);
+        }
         return baseUnitAmount;
     }
     /**

--- a/packages/0x.js/test/0x.js_test.ts
+++ b/packages/0x.js/test/0x.js_test.ts
@@ -114,6 +114,12 @@ describe('ZeroEx library', () => {
         });
     });
     describe('#toUnitAmount', () => {
+        it('should throw if invalid baseUnit amount supplied as argument', () => {
+            const invalidBaseUnitAmount = new BigNumber(1000000000.4);
+            const decimals = 6;
+            expect(() => ZeroEx.toUnitAmount(invalidBaseUnitAmount, decimals))
+                .to.throw('amount should be in baseUnits (no decimals), found value: 1000000000.4');
+        });
         it('Should return the expected unit amount for the decimals passed in', () => {
             const baseUnitAmount = new BigNumber(1000000000);
             const decimals = 6;

--- a/packages/0x.js/test/0x.js_test.ts
+++ b/packages/0x.js/test/0x.js_test.ts
@@ -136,6 +136,12 @@ describe('ZeroEx library', () => {
             const expectedUnitAmount = new BigNumber(1000000000);
             expect(baseUnitAmount).to.be.bignumber.equal(expectedUnitAmount);
         });
+        it('should throw if unitAmount has more decimals then specified as the max decimal precision', () => {
+            const unitAmount = new BigNumber(0.823091);
+            const decimals = 5;
+            expect(() => ZeroEx.toBaseUnitAmount(unitAmount, decimals))
+                .to.throw('Invalid unit amount: 0.823091 - Too many decimal places');
+        });
     });
     describe('#getOrderHashHex', () => {
         const expectedOrderHash = '0x39da987067a3c9e5f1617694f1301326ba8c8b0498ebef5df4863bed394e3c83';


### PR DESCRIPTION
This PR:
* Throw if amount with too many decimal places is passed into `toBaseUnitAmount`
* Assert that valid baseUnit amount is passed into `toUnitAmount`
* Add tests for both of the above edge cases
