### PR TITLE
Add missing calls to bigNumberConfigs in packages where we are instan…

### DIFF
--- a/packages/connect/package.json
+++ b/packages/connect/package.json
@@ -38,6 +38,7 @@
   "dependencies": {
     "@0xproject/assert": "^0.0.8",
     "@0xproject/json-schemas": "^0.7.0",
+    "@0xproject/utils": "^0.1.1",
     "bignumber.js": "~4.1.0",
     "isomorphic-fetch": "^2.2.1",
     "lodash": "^4.17.4",

--- a/packages/connect/src/http_client.ts
+++ b/packages/connect/src/http_client.ts
@@ -21,11 +21,6 @@ import {
 } from './types';
 import {typeConverters} from './utils/type_converters';
 
-// TODO: move this and bigNumberConfigs in the 0x.js package into one place
-BigNumber.config({
-    EXPONENTIAL_AT: 1000,
-});
-
 /**
  * This class includes all the functionality related to interacting with a set of HTTP endpoints
  * that implement the standard relayer API v0

--- a/packages/connect/src/http_client.ts
+++ b/packages/connect/src/http_client.ts
@@ -1,6 +1,5 @@
 import {assert} from '@0xproject/assert';
 import {schemas} from '@0xproject/json-schemas';
-import {BigNumber} from 'bignumber.js';
 import 'isomorphic-fetch';
 import * as _ from 'lodash';
 import * as queryString from 'query-string';

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -1,3 +1,8 @@
+import {bigNumberConfigs} from '@0xproject/utils';
+
+// Customize our BigNumber instances
+bigNumberConfigs.configure();
+
 export {HttpClient} from './http_client';
 export {WebSocketOrderbookChannel} from './ws_orderbook_channel';
 export {

--- a/packages/web3-wrapper/src/index.ts
+++ b/packages/web3-wrapper/src/index.ts
@@ -1,5 +1,8 @@
 import {TransactionReceipt, TxData} from '@0xproject/types';
-import {promisify} from '@0xproject/utils';
+import {
+    bigNumberConfigs,
+    promisify,
+} from '@0xproject/utils';
 import BigNumber from 'bignumber.js';
 import * as _ from 'lodash';
 import * as Web3 from 'web3';
@@ -14,6 +17,9 @@ interface RawLogEntry {
     data: string;
     topics: string[];
 }
+
+// Customize our BigNumber instances
+bigNumberConfigs.configure();
 
 export class Web3Wrapper {
     private _web3: Web3;


### PR DESCRIPTION
…tiating BigNumbers

This PR:
* We need to call `bigNumberConfigs.configure()` in packages where we are creating instances BigNumber
* Not doing so may cause BigNumber's `toString()` method to render the number in exponential notation
