### PR TITLE
Fix array typing generation when permitting multiple types

### DIFF
--- a/packages/abi-gen/src/utils.ts
+++ b/packages/abi-gen/src/utils.ts
@@ -10,7 +10,7 @@ export const utils = {
         if (solType.match(trailingArrayRegex)) {
             const arrayItemSolType = solType.replace(trailingArrayRegex, '');
             const arrayItemTsType = utils.solTypeToTsType(paramKind, arrayItemSolType);
-            const arrayTsType = `${arrayItemTsType}[]`;
+            const arrayTsType = `(${arrayItemTsType})[]`;
             return arrayTsType;
         } else {
             const solTypeRegexToTsType = [


### PR DESCRIPTION
Incorrect typings were being generated when an array type consisted of elements separated by an | operator.  For instance, if the constituent element of the array was a `number|BigNumber`, the generated array type would be `number|BigNumber[]`.

Fixed by grouping all constituent elements in a type array with parentheses. 
