### PR TITLE
Added constructor ABIs to abi-gen

### DIFF
--- a/packages/abi-gen/package.json
+++ b/packages/abi-gen/package.json
@@ -43,6 +43,6 @@
     "shx": "^0.2.2",
     "tslint": "5.8.0",
     "typescript": "~2.6.1",
-    "web3-typescript-typings": "^0.7.2"
+    "web3-typescript-typings": "^0.9.0"
   }
 }

--- a/packages/abi-gen/src/index.ts
+++ b/packages/abi-gen/src/index.ts
@@ -14,6 +14,7 @@ import * as Web3 from 'web3';
 import { ContextData, ParamKind } from './types';
 import { utils } from './utils';
 
+const ABI_TYPE_CONSTRUCTOR = 'constructor';
 const ABI_TYPE_METHOD = 'function';
 const ABI_TYPE_EVENT = 'event';
 const MAIN_TEMPLATE_NAME = 'contract.mustache';
@@ -75,6 +76,11 @@ for (const abiFileName of abiFileNames) {
         process.exit(1);
     }
 
+    let constructor = ABI.find((abi: Web3.AbiDefinition) => abi.type === ABI_TYPE_CONSTRUCTOR) as Web3.ConstructorAbi;
+    if (!constructor) {
+        constructor = utils.getEmptyConstructor(); // The constructor exists, but it's implicit in JSON's ABI definition
+    }
+
     const methodAbis = ABI.filter((abi: Web3.AbiDefinition) => abi.type === ABI_TYPE_METHOD) as Web3.MethodAbi[];
     const methodsData = _.map(methodAbis, methodAbi => {
         _.map(methodAbi.inputs, input => {
@@ -95,6 +101,7 @@ for (const abiFileName of abiFileNames) {
 
     const contextData = {
         contractName: namedContent.name,
+        constructor,
         methods: methodsData,
         events: eventAbis,
     };

--- a/packages/abi-gen/src/utils.ts
+++ b/packages/abi-gen/src/utils.ts
@@ -1,6 +1,7 @@
 import * as fs from 'fs';
 import * as _ from 'lodash';
 import * as path from 'path';
+import * as Web3 from 'web3';
 
 import { ParamKind } from './types';
 
@@ -55,5 +56,13 @@ export const utils = {
         } catch (err) {
             throw new Error(`Failed to read ${filename}: ${err}`);
         }
+    },
+    getEmptyConstructor(): Web3.ConstructorAbi {
+        return {
+            type: 'constructor',
+            stateMutability: 'nonpayable',
+            payable: false,
+            inputs: [],
+        };
     },
 };

--- a/yarn.lock
+++ b/yarn.lock
@@ -9450,6 +9450,12 @@ web3-typescript-typings@^0.7.2:
   dependencies:
     bignumber.js "^4.0.2"
 
+web3-typescript-typings@^0.9.0:
+  version "0.9.0"
+  resolved "https://registry.yarnpkg.com/web3-typescript-typings/-/web3-typescript-typings-0.9.0.tgz#c658db3c84427d9c05a93613e35e6d8147c931c4"
+  dependencies:
+    bignumber.js "^4.0.2"
+
 web3-utils@^1.0.0-beta.26:
   version "1.0.0-beta.26"
   resolved "https://registry.yarnpkg.com/web3-utils/-/web3-utils-1.0.0-beta.26.tgz#f04ad8c144b1781c6b20c2818e0532cb9e6dca15"


### PR DESCRIPTION
Additionally if the constructor is not existent in JSON, meaning it's
implicite with no parameters, we're
explicitly creating one, with actual JSON parameters that it should have.
