### PR TITLE
Fix web3 typing defaultAccount not allowing `undefined`

### DIFF
--- a/packages/web3-typescript-typings/CHANGELOG.md
+++ b/packages/web3-typescript-typings/CHANGELOG.md
@@ -3,4 +3,4 @@
 ## v0.9.3 - _January 11, 2018_
 
 * Add type for getData on a contract
-* Fixed the `defaultAccount` not allowing for `undefined` value
+* Fixed the `defaultAccount` not allowing for `undefined` value (#320)

--- a/packages/web3-typescript-typings/CHANGELOG.md
+++ b/packages/web3-typescript-typings/CHANGELOG.md
@@ -3,3 +3,4 @@
 ## v0.9.3 - _January 11, 2018_
 
 * Add type for getData on a contract
+* Fixed the `defaultAccount` not allowing for `undefined` value

--- a/packages/web3-typescript-typings/index.d.ts
+++ b/packages/web3-typescript-typings/index.d.ts
@@ -170,7 +170,7 @@ declare module 'web3' {
             gasPrice: BigNumber.BigNumber;
             accounts: string[];
             blockNumber: number;
-            defaultAccount: string;
+            defaultAccount?: string;
             defaultBlock: Web3.BlockParam;
             syncing: Web3.SyncingResult;
             compile: {


### PR DESCRIPTION
The default value for the defaultAccount property is undefined,
this happens in real-life scenarios, and so the type should
explicitly warn users about it
