### PR TITLE
Fix fillOrdersUpTo validation

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -3,8 +3,8 @@
 ## v0.x.x - _TBD, 2018_
 
     * Add an error parameter to the order watcher callback (#312)
-    * Fix the bug making it impossible to catch some errors from awaitTransactionMinedAsync (#312)
-    * Fix the bug in fillOrdersUpTo validation making it impossible to fill up to if user doesn't have enough balance to fully fill all the orders (#321)
+    * Fix a bug making it impossible to catch some errors from awaitTransactionMinedAsync (#312)
+    * Fix a bug in fillOrdersUpTo validation making it impossible to fill up to if user doesn't have enough balance to fully fill all the orders (#321)
 
 ## v0.29.1 - _January 11, 2018_
 

--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -4,6 +4,7 @@
 
     * Add an error parameter to the order watcher callback (#312)
     * Fix the bug making it impossible to catch some errors from awaitTransactionMinedAsync (#312)
+    * Fix the bug in fillOrdersUpTo validation making it impossible to fill up to if user doesn't have enough balance to fully fill all the orders (#321)
 
 ## v0.29.1 - _January 11, 2018_
 

--- a/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
@@ -258,16 +258,18 @@ export class ExchangeWrapper extends ContractWrapper {
             ? SHOULD_VALIDATE_BY_DEFAULT
             : orderTransactionOpts.shouldValidate;
         if (shouldValidate) {
+            let filledTakerTokenAmount = new BigNumber(0);
             const zrxTokenAddress = this.getZRXTokenAddress();
             const exchangeTradeEmulator = new ExchangeTransferSimulator(this._tokenWrapper, BlockParamLiteral.Latest);
             for (const signedOrder of signedOrders) {
-                await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
+                const singleFilledTakerTokenAmount = await this._orderValidationUtils.validateFillOrderThrowIfInvalidAsync(
                     exchangeTradeEmulator,
                     signedOrder,
-                    fillTakerTokenAmount,
+                    fillTakerTokenAmount.minus(filledTakerTokenAmount),
                     takerAddress,
                     zrxTokenAddress,
                 );
+                filledTakerTokenAmount = filledTakerTokenAmount.plus(singleFilledTakerTokenAmount);
             }
         }
 

--- a/packages/0x.js/test/exchange_wrapper_test.ts
+++ b/packages/0x.js/test/exchange_wrapper_test.ts
@@ -550,7 +550,7 @@ describe('ExchangeWrapper', () => {
                     const remainingFillAmount = fillableAmount.minus(1);
                     expect(anotherFilledAmount).to.be.bignumber.equal(remainingFillAmount);
                 });
-                it('should successfully fill up to specified amount even if filling all orders will fail', async () => {
+                it('should successfully fill up to specified amount even if filling all orders would fail', async () => {
                     const missingBalance = new BigNumber(1); // User will still have enough balance to fill up to 9,
                     // but won't have 10 to fully fill all orders in a batch.
                     await zeroEx.token.transferAsync(makerTokenAddress, makerAddress, coinbase, missingBalance);
@@ -569,8 +569,8 @@ describe('ExchangeWrapper', () => {
                 });
             });
             describe('failed batch fills', () => {
-                it("should fail validation if user doesn't have enough balance wo fill up to", async () => {
-                    const missingBalance = new BigNumber(2); // User will only have anough balance to fill up to 8
+                it("should fail validation if user doesn't have enough balance without fill up to", async () => {
+                    const missingBalance = new BigNumber(2); // User will only have enough balance to fill up to 8
                     await zeroEx.token.transferAsync(makerTokenAddress, makerAddress, coinbase, missingBalance);
                     return expect(
                         zeroEx.exchange.fillOrdersUpToAsync(

--- a/packages/0x.js/test/exchange_wrapper_test.ts
+++ b/packages/0x.js/test/exchange_wrapper_test.ts
@@ -568,6 +568,20 @@ describe('ExchangeWrapper', () => {
                     expect(anotherFilledAmount).to.be.bignumber.equal(remainingFillAmount);
                 });
             });
+            describe('failed batch fills', () => {
+                it("should fail validation if user doesn't have enough balance wo fill up to", async () => {
+                    const missingBalance = new BigNumber(2); // User will only have anough balance to fill up to 8
+                    await zeroEx.token.transferAsync(makerTokenAddress, makerAddress, coinbase, missingBalance);
+                    return expect(
+                        zeroEx.exchange.fillOrdersUpToAsync(
+                            signedOrders,
+                            fillUpToAmount,
+                            shouldThrowOnInsufficientBalanceOrAllowance,
+                            takerAddress,
+                        ),
+                    ).to.be.rejectedWith(ExchangeContractErrs.InsufficientMakerBalance);
+                });
+            });
             describe('order transaction options', () => {
                 const emptyFillUpToAmount = new BigNumber(0);
                 it('should validate when orderTransactionOptions are not present', async () => {


### PR DESCRIPTION
This PR:

* Fixes the validation issue in a situation when a user does a market order fill and doesn't have enough balance to fill all orders, but still has enough balance to satisfy his/her market order (`fillOrdersUpTo`)
* Adds tests for that use-case