### PR TITLE
Make the top level package a lerna managed package

### DIFF
--- a/lerna.json
+++ b/lerna.json
@@ -1,6 +1,6 @@
 {
     "lerna": "2.5.1",
-    "packages": ["packages/*"],
+    "packages": ["./", "packages/*"],
     "version": "independent",
     "npmClient": "yarn",
     "useWorkspaces": true

--- a/yarn.lock
+++ b/yarn.lock
@@ -2,14 +2,6 @@
 # yarn lockfile v1
 
 
-"@0xproject/utils@^0.1.0":
-  version "0.1.3"
-  resolved "https://registry.yarnpkg.com/@0xproject/utils/-/utils-0.1.3.tgz#58a9c7e19ab7710e0af17a0c2f1c7fc1b3140e85"
-  dependencies:
-    bignumber.js "~4.1.0"
-    js-sha3 "^0.7.0"
-    lodash "^4.17.4"
-
 "@types/accounting@^0.4.1":
   version "0.4.1"
   resolved "https://registry.yarnpkg.com/@types/accounting/-/accounting-0.4.1.tgz#865d9f5694fd7c438fba34eb4bc82eec6f34cdd5"


### PR DESCRIPTION
This PR:
* Adds `./` as a top managed package to lerna
* This resolves the issue we saw here: https://github.com/0xProject/0x.js/pull/326 where our top level @0xproject/utils dependency does not get automatically updated on publish
* This fix is proposed but warned against here: https://github.com/lerna/lerna/issues/1216
* w/o this change we just need to remember to manually update versions in our top level directory, also `yarn install` won't link to the local version of @0xproject/utils, causing local changes not to be reflected