### PR TITLE
Allow Token symbols to be alphanumeric

### DIFF
--- a/packages/website/ts/components/generate_order/new_token_form.tsx
+++ b/packages/website/ts/components/generate_order/new_token_form.tsx
@@ -189,8 +189,8 @@ export class NewTokenForm extends React.Component<NewTokenFormProps, NewTokenFor
         const tokenWithSymbolExists = !_.isUndefined(_.find(tokens, { symbol }));
         if (symbol === '') {
             symbolErrText = 'Symbol is required';
-        } else if (!this._isLetters(symbol)) {
-            symbolErrText = 'Can only include letters';
+        } else if (!this._isAlphanumeric(symbol)) {
+            symbolErrText = 'Can only include alphanumeric characters';
         } else if (symbol.length > maxLength) {
             symbolErrText = `Max length is ${maxLength}`;
         } else if (tokenWithSymbolExists) {
@@ -231,7 +231,7 @@ export class NewTokenForm extends React.Component<NewTokenFormProps, NewTokenFor
     private _isInteger(input: string) {
         return /^[0-9]+$/i.test(input);
     }
-    private _isLetters(input: string) {
-        return /^[a-zA-Z]+$/i.test(input);
+    private _isAlphanumeric(input: string) {
+        return /^[a-zA-Z0-9]+$/i.test(input);
     }
 }


### PR DESCRIPTION
Allows alphanumeric characters in token symbols to be added to the portal. Previously a validation was failing preventing the token from being added to the Portal.

We already allow Alphanumeric when hardcoded in the config, i.e First Blood 1ST
