### PR TITLE
Issue/Pull Request Template

### DIFF
--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,0 +1,59 @@
+<!--- Before submitting please check the current Issues to see if it was already reported -->
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Expected Behavior
+
+<!--- If you're describing a bug, tell us what should happen -->
+
+<!--- If you're suggesting a package change/improvement, tell us how it should work -->
+
+<!--- If you're suggesting a contract or protocol change/improvement, visit our ZEIPs repo -->
+
+## Current Behavior
+
+<!--- If describing a bug, tell us what happens instead of the expected behavior -->
+
+<!--- If suggesting a change/improvement, explain the difference from current behavior -->
+
+## Possible Solution
+
+<!--- Not obligatory, but suggest a fix/reason for the bug, -->
+
+<!--- or ideas how to implement the addition or change -->
+
+## Steps to Reproduce (for bugs)
+
+<!--- Provide a link to a live example, or an unambiguous set of steps to -->
+
+<!--- reproduce this bug. Include code to reproduce, if relevant -->
+
+```
+1.
+2.
+3.
+```
+
+## Context
+
+<!--- How has this issue affected you? What are you trying to accomplish? -->
+
+<!--- Providing context helps us come up with a solution that is most useful in the real world -->
+
+## Your Environment
+
+<!--- Include as many relevant details about the environment you experienced the bug in -->
+
+|             Package | Version |
+| ------------------: | :------ |
+|             `0x.js` | 0.25.0  |
+| `Exchange Contract` | v1      |
+
+| Network |
+| ------- |
+| NAME    |
+
+<!-- For example:
+| mainnet |
+| kovan |
+| testrpc |
+-->

--- a/ISSUE_TEMPLATE.md
+++ b/ISSUE_TEMPLATE.md
@@ -1,4 +1,7 @@
-<!--- Before submitting please check the current Issues to see if it was already reported -->
+<!--- Thank you for taking the time to file an Issue -->
+
+<!--- Before submitting please check to see if this issue was already reported -->
+
 <!--- Provide a general summary of the issue in the Title above -->
 
 ## Expected Behavior

--- a/PULL_REQUEST_TEMPLATE.md
+++ b/PULL_REQUEST_TEMPLATE.md
@@ -1,3 +1,36 @@
-This PR:
+<!--- Thank you for taking the time to submit a Pull Request -->
 
-\*
+<!--- Provide a general summary of the issue in the Title above -->
+
+## Description
+
+<!--- Describe your changes in detail -->
+
+## Motivation and Context
+
+<!--- Why is this change required? What problem does it solve? -->
+
+<!--- If it fixes an open issue, please link to the issue here. -->
+
+## How Has This Been Tested?
+
+<!--- Please describe in detail how you tested your changes. -->
+
+<!--- Include details of your testing environment, and the tests you ran to -->
+
+<!--- see how your change affects other areas of the code, etc. -->
+
+## Types of changes
+
+<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
+- [ ] Bug fix (non-breaking change which fixes an issue)
+- [ ] New feature (non-breaking change which adds functionality)
+- [ ] Breaking change (fix or feature that would cause existing functionality to change)
+
+## Checklist:
+<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->
+
+<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->
+
+* [ ] Change requires a change to the documentation.
+* [ ] Added tests to cover my changes.


### PR DESCRIPTION
Updated the default Issue/Pull Request templates.

Provides a templated guide for outside commiters to follow a particular format. Mostly hijacked from Lerna.