### PR TITLE
Fix getTransactionReceipt not returning null

### DIFF
--- a/packages/web3-typescript-typings/CHANGELOG.md
+++ b/packages/web3-typescript-typings/CHANGELOG.md
@@ -2,5 +2,6 @@
 
 ## v0.9.3 - _January 11, 2018_
 
+* Fix `getTransactionReceipt` not returning null (#338)
 * Add type for getData on a contract
 * Fixed the `defaultAccount` not allowing for `undefined` value (#320)

--- a/packages/web3-typescript-typings/index.d.ts
+++ b/packages/web3-typescript-typings/index.d.ts
@@ -257,10 +257,10 @@ declare module 'web3' {
             sign(address: string, data: string): string;
             sign(address: string, data: string, callback: (err: Error, signature: string) => void): void;
 
-            getTransactionReceipt(txHash: string): Web3.TransactionReceipt;
+            getTransactionReceipt(txHash: string): Web3.TransactionReceipt | null;
             getTransactionReceipt(
                 txHash: string,
-                callback: (err: Error, receipt: Web3.TransactionReceipt) => void,
+                callback: (err: Error, receipt: Web3.TransactionReceipt | null) => void,
             ): void;
 
             // TODO block param


### PR DESCRIPTION
If the transaction is not yet put into blockchain, using `getTransactionReceipt` will return null.