### PR TITLE
Fix the bug making it impossible to specify the custom ZRX address

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.30.1 - _January 18, 2018_
 
     * Fix a bug allowing negative fill values  (#212)
+    * Fix a bug that made it impossible to pass a custom ZRX address  (#341)
 
 ## v0.30.0 - _January 17, 2018_
 

--- a/packages/0x.js/src/0x.ts
+++ b/packages/0x.js/src/0x.ts
@@ -191,6 +191,7 @@ export class ZeroEx {
             this._abiDecoder,
             this.token,
             config.exchangeContractAddress,
+            config.zrxContractAddress,
         );
         this.tokenRegistry = new TokenRegistryWrapper(
             this._web3Wrapper,

--- a/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
@@ -87,11 +87,13 @@ export class ExchangeWrapper extends ContractWrapper {
         abiDecoder: AbiDecoder,
         tokenWrapper: TokenWrapper,
         contractAddressIfExists?: string,
+        zrxContractAddressIfExists?: string,
     ) {
         super(web3Wrapper, networkId, abiDecoder);
         this._tokenWrapper = tokenWrapper;
         this._orderValidationUtils = new OrderValidationUtils(this);
         this._contractAddressIfExists = contractAddressIfExists;
+        this._zrxContractAddressIfExists = zrxContractAddressIfExists;
     }
     /**
      * Returns the unavailable takerAmount of an order. Unavailable amount is defined as the total

--- a/packages/0x.js/src/types.ts
+++ b/packages/0x.js/src/types.ts
@@ -290,6 +290,7 @@ export interface OrderStateWatcherConfig {
  * networkId: The id of the underlying ethereum network your provider is connected to. (1-mainnet, 42-kovan, 50-testrpc)
  * gasPrice: Gas price to use with every transaction
  * exchangeContractAddress: The address of an exchange contract to use
+ * zrxContractAddress: The address of the ZRX contract to use
  * tokenRegistryContractAddress: The address of a token registry contract to use
  * tokenTransferProxyContractAddress: The address of the token transfer proxy contract to use
  * orderWatcherConfig: All the configs related to the orderWatcher
@@ -298,6 +299,7 @@ export interface ZeroExConfig {
     networkId: number;
     gasPrice?: BigNumber;
     exchangeContractAddress?: string;
+    zrxContractAddress?: string;
     tokenRegistryContractAddress?: string;
     tokenTransferProxyContractAddress?: string;
     orderWatcherConfig?: OrderStateWatcherConfig;


### PR DESCRIPTION
This PR:

* Fixes a bug that made it impossible to use ZRX on custom chains, because we were not passing down the zrx address and it was impossible to onfigure it
