### PR TITLE
BUGFIX: don't remove maker/zrx order from cache twice

### DIFF
--- a/packages/0x.js/src/order_watcher/order_state_watcher.ts
+++ b/packages/0x.js/src/order_watcher/order_state_watcher.ts
@@ -133,8 +133,12 @@ export class OrderStateWatcher {
         delete this._orderStateByOrderHashCache[orderHash];
         const exchange = (this._orderFilledCancelledLazyStore as any)._exchange as ExchangeWrapper;
         const zrxTokenAddress = exchange.getZRXTokenAddress();
+        
         this._removeFromDependentOrderHashes(signedOrder.maker, zrxTokenAddress, orderHash);
-        this._removeFromDependentOrderHashes(signedOrder.maker, signedOrder.makerTokenAddress, orderHash);
+        if (zrxTokenAddress !== signedOrder.makerTokenAddress) {
+            this.removeFromDependentOrderHashes(signedOrder.maker, signedOrder.makerTokenAddress, orderHash);
+        }
+
         this._expirationWatcher.removeOrder(orderHash);
     }
     /**


### PR DESCRIPTION
When removing an order from the watcher cache, we call _removeFromDependentOrderHashes for both the makerTokenAddress and the ZRX token address for fees. The problem is when the makerTokenAddress is the ZRX token address and you call this line:

```
this._dependentOrderHashes[makerAddress][tokenAddress].delete(orderHash);
```

This fails and results in the rest of the script terminating.