### PR TITLE
Change the InjectedWeb3Subprovider to accept Web3.Provider

### DIFF
--- a/packages/subproviders/CHANGELOG.md
+++ b/packages/subproviders/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
-## v0.4.0 - _January 28, 2017_
+## v0.4.0 - _Feburary 02, 2018_
+
+    * InjectedWeb3Subprovider accepts a Provider in the constructor, previously it was a Web3 object.
+
+## v0.3.5 - _January 28, 2018_
 
     * Return a transaction hash from `_sendTransactionAsync` (#303)
 

--- a/packages/subproviders/README.md
+++ b/packages/subproviders/README.md
@@ -2,6 +2,8 @@
 
 A few useful web3 subproviders including a LedgerSubprovider useful for adding Ledger Nano S support.
 
+We have written up a [Wiki](https://0xproject.com/wiki#Web3-Provider-Examples) article detailing some use cases of this subprovider package.
+
 ## Installation
 
 ```

--- a/packages/subproviders/src/subproviders/injected_web3.ts
+++ b/packages/subproviders/src/subproviders/injected_web3.ts
@@ -4,7 +4,7 @@ import Web3 = require('web3');
 /*
  * This class implements the web3-provider-engine subprovider interface and forwards
  * requests involving user accounts (getAccounts, sendTransaction, etc...) to the injected
- * MetamaskInpageProvider instance in their browser.
+ * provider instance in their browser.
  * Source: https://github.com/MetaMask/provider-engine/blob/master/subproviders/subprovider.js
  */
 export class InjectedWeb3Subprovider {
@@ -41,6 +41,7 @@ export class InjectedWeb3Subprovider {
         }
     }
     // Required to implement this method despite not needing it for this subprovider
+    // This type is Web3ProviderEngine, but there is no need to import this for a noop.
     // tslint:disable-next-line:prefer-function-over-method
     public setEngine(engine: any) {
         // noop

--- a/packages/subproviders/src/subproviders/injected_web3.ts
+++ b/packages/subproviders/src/subproviders/injected_web3.ts
@@ -1,17 +1,16 @@
 import * as _ from 'lodash';
 import Web3 = require('web3');
-import Web3ProviderEngine = require('web3-provider-engine');
 
 /*
  * This class implements the web3-provider-engine subprovider interface and forwards
  * requests involving user accounts (getAccounts, sendTransaction, etc...) to the injected
- * web3 instance in their browser.
+ * MetamaskInpageProvider instance in their browser.
  * Source: https://github.com/MetaMask/provider-engine/blob/master/subproviders/subprovider.js
  */
 export class InjectedWeb3Subprovider {
     private _injectedWeb3: Web3;
-    constructor(injectedWeb3: Web3) {
-        this._injectedWeb3 = injectedWeb3;
+    constructor(subprovider: Web3.Provider) {
+        this._injectedWeb3 = new Web3(subprovider);
     }
     public handleRequest(
         payload: Web3.JSONRPCRequestPayload,
@@ -43,7 +42,7 @@ export class InjectedWeb3Subprovider {
     }
     // Required to implement this method despite not needing it for this subprovider
     // tslint:disable-next-line:prefer-function-over-method
-    public setEngine(engine: Web3ProviderEngine) {
+    public setEngine(engine: any) {
         // noop
     }
 }

--- a/packages/website/ts/blockchain.ts
+++ b/packages/website/ts/blockchain.ts
@@ -100,7 +100,7 @@ export class Blockchain {
             // We catch all requests involving a users account and send it to the injectedWeb3
             // instance. All other requests go to the public hosted node.
             provider = new ProviderEngine();
-            provider.addProvider(new InjectedWeb3Subprovider(injectedWeb3));
+            provider.addProvider(new InjectedWeb3Subprovider(injectedWeb3.currentProvider));
             provider.addProvider(new FilterSubprovider());
             provider.addProvider(new RedundantRPCSubprovider(publicNodeUrlsIfExistsForNetworkId));
             provider.start();


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

<!--- Describe your changes in detail -->
Remove the requirement to pass in a Web3 object to InjectedWeb3Subprovider and accept a Web3 Provider.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

Allows us to use a controlled version of Web3.

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

Manually tested in Website which uses InjectedWeb3 provider.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply:
- [ ] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [x] Breaking change (fix or feature that would cause existing functionality to change)

This is a public api and breaks previous uses

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
