### PR TITLE
Fix an exception when a signature collision happens

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.x.x - _TBD, 2018_
 
-    * Fixed the bug causing order watcher to throw if there is the event with the same signature but different indexed fields (#)
+    * Fixed the bug causing order watcher to throw if there is the event with the same signature but different indexed fields (#366)
 
 ## v0.31.1 - _February 1, 2018_
 

--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -1,5 +1,9 @@
 # CHANGELOG
 
+## v0.x.x - _TBD, 2018_
+
+    * Fixed the bug causing order watcher to throw if there is the event with the same signature but different indexed fields (#)
+
 ## v0.31.1 - _February 1, 2018_
 
     * Fix the bug causing order watcher to throw is makerToken === zrx (#357)

--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -2,8 +2,8 @@
 
 ## v0.x.x - _TBD, 2018_
 
-    * Fixed the bug causing order watcher to throw if there is the event with the same signature but different indexed fields (#366)
     * Add `zeroEx.etherToken.getContractAddressIfExists` (#350)
+    * Fixed the bug causing order watcher to throw if there is an event with the same signature but different indexed fields (#366)
 
 ## v0.31.1 - _February 1, 2018_
 

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -1,6 +1,10 @@
 # CHANGELOG
 
+## v0.x.x - _TBD, 2018_
+
+    * Fix a bug causing abi_decoder to throw on unknown events with the same signature (#366)
+
 ## v0.2.0 - _January 17, 2018_
 
-* Add `onError` parameter to `intervalUtils.setAsyncExcludingInterval` (#312)
-* Add `intervalUtils.setInterval` (#312)
+    * Add `onError` parameter to `intervalUtils.setAsyncExcludingInterval` (#312)
+    * Add `intervalUtils.setInterval` (#312)

--- a/packages/utils/CHANGELOG.md
+++ b/packages/utils/CHANGELOG.md
@@ -2,7 +2,7 @@
 
 ## v0.x.x - _TBD, 2018_
 
-    * Fix a bug causing abi_decoder to throw on unknown events with the same signature (#366)
+    * Fix a bug related to event signature collisions (argument indexes aren't included in event signatures) in the abi_decoder. The decoder used to throw on unknown events with identical signatures as a known event (except indexes). (#366)
 
 ## v0.2.0 - _January 17, 2018_
 

--- a/packages/utils/src/abi_decoder.ts
+++ b/packages/utils/src/abi_decoder.ts
@@ -18,7 +18,7 @@ export class AbiDecoder {
         return `0x${formatted}`;
     }
     constructor(abiArrays: Web3.AbiDefinition[][]) {
-        _.map(abiArrays, this._addABI.bind(this));
+        _.forEach(abiArrays, this._addABI.bind(this));
     }
     // This method can only decode logs from the 0x & ERC20 smart contracts
     public tryToDecodeLogOrNoop<ArgsType>(log: Web3.LogEntry): LogWithDecodedArgs<ArgsType> | RawLog {
@@ -37,7 +37,7 @@ export class AbiDecoder {
         const decodedData = SolidityCoder.decodeParams(dataTypes, logData.slice('0x'.length));
 
         let failedToDecode = false;
-        _.map(event.inputs, (param: Web3.EventParameter) => {
+        _.forEach(event.inputs, (param: Web3.EventParameter) => {
             // Indexed parameters are stored in topics. Non-indexed ones in decodedData
             let value: BigNumber | string = param.indexed ? log.topics[topicsIndex++] : decodedData[dataIndex++];
             if (_.isUndefined(value)) {

--- a/packages/utils/src/abi_decoder.ts
+++ b/packages/utils/src/abi_decoder.ts
@@ -36,9 +36,14 @@ export class AbiDecoder {
         const dataTypes = _.map(nonIndexedInputs, input => input.type);
         const decodedData = SolidityCoder.decodeParams(dataTypes, logData.slice('0x'.length));
 
+        let failedToDecode = false;
         _.map(event.inputs, (param: Web3.EventParameter) => {
             // Indexed parameters are stored in topics. Non-indexed ones in decodedData
             let value: BigNumber | string = param.indexed ? log.topics[topicsIndex++] : decodedData[dataIndex++];
+            if (_.isUndefined(value)) {
+                failedToDecode = true;
+                return;
+            }
             if (param.type === SolidityTypes.Address) {
                 value = AbiDecoder._padZeros(new BigNumber(value).toString(16));
             } else if (
@@ -51,11 +56,15 @@ export class AbiDecoder {
             decodedParams[param.name] = value;
         });
 
-        return {
-            ...log,
-            event: event.name,
-            args: decodedParams,
-        };
+        if (failedToDecode) {
+            return log;
+        } else {
+            return {
+                ...log,
+                event: event.name,
+                args: decodedParams,
+            };
+        }
     }
     private _addABI(abiArray: Web3.AbiDefinition[]): void {
         _.map(abiArray, (abi: Web3.AbiDefinition) => {


### PR DESCRIPTION
Fixes an exception in an order watcher when we have an event with the same signature as one of the known events, but it has different indexed fields and therefore fails to decode.

## Description

`Deposit(address a, uint b);`
and
`Deposit(address indexed a, uint b);`
have the same signature, but are encoded differently.

## Motivation and Context

## How Has This Been Tested?

Manual tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

- [x] Bug fix (non-breaking change which fixes an issue)
- [ ] New feature (non-breaking change which adds functionality)
- [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:
<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.


Closes #365 