### PR TITLE
web3-typescript-typings fix - web3.net.peerCount returns number

### DIFF
--- a/packages/web3-typescript-typings/index.d.ts
+++ b/packages/web3-typescript-typings/index.d.ts
@@ -298,7 +298,7 @@ declare module 'web3' {
 
         interface NetApi {
             listening: boolean;
-            peerCount: boolean;
+            peerCount: number;
             getListening(cd: (err: Error, listening: boolean) => void): void;
             getPeerCount(cd: (err: Error, peerCount: number) => void): void;
         }


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

Fixes return type of NetApi.peerCount from `boolean` to `number` in package `web3-typescript-typings`

<!--- Describe your changes in detail -->

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

<!--- Please describe in detail how you tested your changes. -->

<!--- Include details of your testing environment, and the tests you ran to -->

<!--- see how your change affects other areas of the code, etc. -->

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
* [ ] Added new entries to the relevant CHANGELOGs.
* [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
* [ ] Labeled this PR with the labels corresponding to the changed package.
