### PR TITLE
Add support for intersection types and staged connect documentation

### DIFF
--- a/packages/0x.js/scripts/stagedocs.js
+++ b/packages/0x.js/scripts/stagedocs.js
@@ -2,7 +2,7 @@ const execAsync = require('async-child-process').execAsync;
 const postpublish_utils = require('../../../scripts/postpublish_utils');
 
 const cwd = __dirname + '/..';
-const S3BucketPath = 's3://staging-connect-docs-jsons/';
+const S3BucketPath = 's3://staging-0xjs-docs-jsons/';
 const jsonFilePath = __dirname + '/../' + postpublish_utils.generatedDocsDirectoryName + '/index.json';
 const version = process.env.DOCS_VERSION;
 

--- a/packages/connect/scripts/stagedocs.js
+++ b/packages/connect/scripts/stagedocs.js
@@ -1,0 +1,26 @@
+const execAsync = require('async-child-process').execAsync;
+const postpublish_utils = require('../../../scripts/postpublish_utils');
+const packageJSON = require('../package.json');
+
+const cwd = __dirname + '/..';
+const subPackageName = packageJSON.name;
+const S3BucketPath = 's3://staging-connect-docs-jsons/';
+const jsonFilePath = __dirname + '/../' + postpublish_utils.generatedDocsDirectoryName + '/index.json';
+const version = process.env.DOCS_VERSION;
+
+execAsync('JSON_FILE_PATH=' + jsonFilePath + ' PROJECT_DIR=' + __dirname + '/.. yarn docs:json', {
+    cwd,
+})
+.then(function(result) {
+    if (result.stderr !== '') {
+        throw new Error(result.stderr);
+    }
+    const fileName = 'v' + version + '.json';
+    const s3Url = S3BucketPath + fileName;
+    return execAsync('S3_URL=' + s3Url + ' yarn upload_docs_json', {
+        cwd,
+    });
+})
+.catch(function(err) {
+    console.log(err);
+});

--- a/packages/website/ts/containers/connect_documentation.tsx
+++ b/packages/website/ts/containers/connect_documentation.tsx
@@ -6,7 +6,8 @@ import { DocsInfo } from 'ts/pages/documentation/docs_info';
 import { Documentation as DocumentationComponent, DocumentationAllProps } from 'ts/pages/documentation/documentation';
 import { Dispatcher } from 'ts/redux/dispatcher';
 import { State } from 'ts/redux/reducer';
-import { DocsInfoConfig, WebsitePaths } from 'ts/types';
+import { DocsInfoConfig, Environments, WebsitePaths } from 'ts/types';
+import { configs } from 'ts/utils/configs';
 import { constants } from 'ts/utils/constants';
 import { typeDocUtils } from 'ts/utils/typedoc_utils';
 
@@ -23,12 +24,16 @@ const connectDocSections = {
     types: constants.TYPES_SECTION_NAME,
 };
 
+const s3BucketName =
+    configs.ENVIRONMENT === Environments.DEVELOPMENT ? 'staging-connect-docs-jsons' : 'connect-docs-jsons';
+const docsJsonRoot = `https://s3.amazonaws.com/${s3BucketName}`;
+
 const docsInfoConfig: DocsInfoConfig = {
     displayName: '0x Connect',
     subPackageName: 'connect',
     packageUrl: 'https://github.com/0xProject/0x.js',
     websitePath: WebsitePaths.Connect,
-    docsJsonRoot: 'https://s3.amazonaws.com/connect-docs-jsons',
+    docsJsonRoot,
     menu: {
         introduction: [connectDocSections.introduction],
         install: [connectDocSections.installation],

--- a/packages/website/ts/containers/zero_ex_js_documentation.tsx
+++ b/packages/website/ts/containers/zero_ex_js_documentation.tsx
@@ -6,7 +6,8 @@ import { DocsInfo } from 'ts/pages/documentation/docs_info';
 import { Documentation as DocumentationComponent, DocumentationAllProps } from 'ts/pages/documentation/documentation';
 import { Dispatcher } from 'ts/redux/dispatcher';
 import { State } from 'ts/redux/reducer';
-import { DocsInfoConfig, WebsitePaths } from 'ts/types';
+import { DocsInfoConfig, Environments, WebsitePaths } from 'ts/types';
+import { configs } from 'ts/utils/configs';
 import { constants } from 'ts/utils/constants';
 import { typeDocUtils } from 'ts/utils/typedoc_utils';
 
@@ -35,12 +36,16 @@ const zeroExJsDocSections = {
     types: constants.TYPES_SECTION_NAME,
 };
 
+const s3BucketName =
+    configs.ENVIRONMENT === Environments.DEVELOPMENT ? 'staging-0xjs-docs-jsons' : '0xjs-docs-jsons';
+const docsJsonRoot = `https://s3.amazonaws.com/${s3BucketName}`;
+
 const docsInfoConfig: DocsInfoConfig = {
     displayName: '0x.js',
     packageUrl: 'https://github.com/0xProject/0x.js',
     subPackageName: '0x.js',
     websitePath: WebsitePaths.ZeroExJs,
-    docsJsonRoot: 'https://s3.amazonaws.com/0xjs-docs-jsons',
+    docsJsonRoot,
     menu: {
         introduction: [zeroExJsDocSections.introduction],
         install: [zeroExJsDocSections.installation],

--- a/packages/website/ts/pages/documentation/type.tsx
+++ b/packages/website/ts/pages/documentation/type.tsx
@@ -118,6 +118,23 @@ export function Type(props: TypeProps): any {
             typeName = type.name;
             break;
 
+        case TypeDocTypes.Intersection:
+            const intersectionsTypes = _.map(type.types, t => {
+                return (
+                    <Type
+                        key={`type-${t.name}-${t.value}-${t.typeDocType}`}
+                        type={t}
+                        sectionName={props.sectionName}
+                        typeDefinitionByName={props.typeDefinitionByName}
+                        docsInfo={props.docsInfo}
+                    />
+                );
+            });
+            typeName = _.reduce(intersectionsTypes, (prev: React.ReactNode, curr: React.ReactNode) => {
+                return [prev, '&', curr];
+            });
+            break;
+
         default:
             throw utils.spawnSwitchErr('type.typeDocType', type.typeDocType);
     }

--- a/packages/website/ts/types.ts
+++ b/packages/website/ts/types.ts
@@ -324,6 +324,7 @@ export enum TypeDocTypes {
     Reflection = 'reflection',
     Union = 'union',
     TypeParameter = 'typeParameter',
+    Intersection = 'intersection',
     Unknown = 'unknown',
 }
 


### PR DESCRIPTION
## Description

Added a script `stagedocs.js` to the `scripts` directory in the connect package. This script will generate and upload docs to the `staging-connect-docs-jsons` s3 bucket. Usage is as follows:

```bash
DOCS_VERSIONS=0.0.2 node scripts/stagedocs.js
```
Specify `DOCS_VERSIONS` to choose the name of the file being written to s3. In the command above, a file named `v0.0.2.json` will be uploaded to the `staging-connect-docs-jsons` bucket.

During development, the website will retreive documentation uploaded to the `staging-connect-docs-jsons` bucket.

## Motivation and Context

Right now it is impossible to test out documentation w/o uploading it to the production bucket first

## How Has This Been Tested?

Manually

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Change requires a change to the documentation.
* [x] Added tests to cover my changes.
* [x] Added new entries to the relevant CHANGELOGs.
* [x] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [x] Labeled this PR with the 'WIP' label if it is a work in progress.
* [x] Labeled this PR with the labels corresponding to the changed package.
