### PR TITLE
Add configurable heartbeat to WebSocketOrderbookChannel

### DIFF
--- a/packages/connect/CHANGELOG.md
+++ b/packages/connect/CHANGELOG.md
@@ -3,6 +3,7 @@
 ## v0.6.0 - _TBD, 2018_
 
     * Add pagination options to HttpClient methods (#393)
+    * Add heartbeat configuration to WebSocketOrderbookChannel constructor (#393)
 
 ## v0.5.7 - _February 9, 2018_
 

--- a/packages/connect/src/index.ts
+++ b/packages/connect/src/index.ts
@@ -17,4 +17,5 @@ export {
     TokenPairsItem,
     TokenPairsRequestOpts,
     TokenTradeInfo,
+    WebSocketOrderbookChannelConfig,
 } from './types';

--- a/packages/connect/src/schemas/schemas.ts
+++ b/packages/connect/src/schemas/schemas.ts
@@ -3,6 +3,7 @@ import { orderBookRequestSchema } from './orderbook_request_schema';
 import { ordersRequestOptsSchema } from './orders_request_opts_schema';
 import { pagedRequestOptsSchema } from './paged_request_opts_schema';
 import { tokenPairsRequestOptsSchema } from './token_pairs_request_opts_schema';
+import { webSocketOrderbookChannelConfigSchema } from './websocket_orderbook_channel_config_schema';
 
 export const schemas = {
     feesRequestSchema,
@@ -10,4 +11,5 @@ export const schemas = {
     ordersRequestOptsSchema,
     pagedRequestOptsSchema,
     tokenPairsRequestOptsSchema,
+    webSocketOrderbookChannelConfigSchema,
 };

--- a/packages/connect/src/schemas/websocket_orderbook_channel_config_schema.ts
+++ b/packages/connect/src/schemas/websocket_orderbook_channel_config_schema.ts
@@ -2,6 +2,9 @@ export const webSocketOrderbookChannelConfigSchema = {
     id: '/WebSocketOrderbookChannelConfig',
     type: 'object',
     properties: {
-        heartbeatIntervalMs: { type: 'number' },
+        heartbeatIntervalMs: {
+            type: 'number',
+            minimum: 10,
+        },
     },
 };

--- a/packages/connect/src/schemas/websocket_orderbook_channel_config_schema.ts
+++ b/packages/connect/src/schemas/websocket_orderbook_channel_config_schema.ts
@@ -1,0 +1,7 @@
+export const webSocketOrderbookChannelConfigSchema = {
+    id: '/WebSocketOrderbookChannelConfig',
+    type: 'object',
+    properties: {
+        heartbeatIntervalMs: { type: 'number' },
+    },
+};

--- a/packages/connect/src/types.ts
+++ b/packages/connect/src/types.ts
@@ -44,6 +44,13 @@ export interface OrderbookChannel {
 }
 
 /*
+ * heartbeatInterval: Interval in milliseconds that the orderbook channel should ping the underlying websocket. Default: 15000
+ */
+export interface WebSocketOrderbookChannelConfig {
+    heartbeatIntervalMs?: number;
+}
+
+/*
  * baseTokenAddress: The address of token designated as the baseToken in the currency pair calculation of price
  * quoteTokenAddress: The address of token designated as the quoteToken in the currency pair calculation of price
  * snapshot: If true, a snapshot of the orderbook will be sent before the updates to the orderbook

--- a/packages/connect/src/ws_orderbook_channel.ts
+++ b/packages/connect/src/ws_orderbook_channel.ts
@@ -16,6 +16,7 @@ import {
 import { orderbookChannelMessageParser } from './utils/orderbook_channel_message_parser';
 
 const DEFAULT_HEARTBEAT_INTERVAL_MS = 15000;
+const MINIMUM_HEARTBEAT_INTERVAL_MS = 10;
 
 /**
  * This class includes all the functionality related to interacting with a websocket endpoint
@@ -104,10 +105,19 @@ export class WebSocketOrderbookChannel implements OrderbookChannel {
         } else {
             this._client.on(WebsocketClientEventType.Connect, connection => {
                 this._connectionIfExists = connection;
-                if (this._heartbeatIntervalMs !== 0) {
+                if (this._heartbeatIntervalMs >= MINIMUM_HEARTBEAT_INTERVAL_MS) {
                     this._heartbeatTimerIfExists = setInterval(() => {
                         connection.ping('');
                     }, this._heartbeatIntervalMs);
+                } else {
+                    callback(
+                        new Error(
+                            `Heartbeat interval is ${
+                                this._heartbeatIntervalMs
+                            }ms which is less than the required minimum of ${MINIMUM_HEARTBEAT_INTERVAL_MS}ms`,
+                        ),
+                        undefined,
+                    );
                 }
                 callback(undefined, this._connectionIfExists);
             });

--- a/packages/website/ts/containers/connect_documentation.tsx
+++ b/packages/website/ts/containers/connect_documentation.tsx
@@ -63,6 +63,7 @@ const docsInfoConfig: DocsInfoConfig = {
         'TokenPairsRequest',
         'TokenPairsRequestOpts',
         'TokenTradeInfo',
+        'WebSocketOrderbookChannelConfig',
         'Order',
         'SignedOrder',
         'ECSignature',


### PR DESCRIPTION
## Description

Add a configurable heartbeat interval to the websocket channel that keeps the socket alive. Different websocket apis may need more or less frequent heartbeats.

## Motivation and Context

Radar recommends its websocket be kept alive with a ping request about every 15s.

## How Has This Been Tested?

`wss://api.kovan.radarrelay.com/0x/v0/ws`

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [ ] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
* [x] Added new entries to the relevant CHANGELOGs.
* [x] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [x] Labeled this PR with the 'WIP' label if it is a work in progress.
* [x] Labeled this PR with the labels corresponding to the changed package.
