### PR TITLE
Fix isBigNumber assertion for new versions of BigNumber

### DIFF
--- a/packages/assert/package.json
+++ b/packages/assert/package.json
@@ -40,6 +40,7 @@
     "dependencies": {
         "@0xproject/json-schemas": "^0.7.12",
         "@0xproject/utils": "^0.3.4",
+        "bignumber.js": "^6.0.0",
         "lodash": "^4.17.4",
         "valid-url": "^1.0.9"
     }

--- a/yarn.lock
+++ b/yarn.lock
@@ -1283,6 +1283,10 @@ big.js@^3.1.3:
   version "3.2.0"
   resolved "https://registry.yarnpkg.com/big.js/-/big.js-3.2.0.tgz#a5fc298b81b9e0dca2e458824784b65c52ba588e"
 
+bignumber.js@^6.0.0:
+  version "6.0.0"
+  resolved "https://registry.yarnpkg.com/bignumber.js/-/bignumber.js-6.0.0.tgz#bbfa047644609a5af093e9cbd83b0461fa3f6002"
+
 "bignumber.js@git+https://github.com/debris/bignumber.js#master":
   version "2.0.7"
   resolved "git+https://github.com/debris/bignumber.js#c7a38de919ed75e6fb6ba38051986e294b328df9"


### PR DESCRIPTION
## Description

Change `isBigNumber` property check in favor of `instanceof BigNumber` check

## Motivation and Context

https://github.com/0xProject/0x.js/issues/403
http://mikemcl.github.io/bignumber.js/#isBigNumber

## How Has This Been Tested?

Unit tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
* [ ] Added new entries to the relevant CHANGELOGs.
* [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [x] Labeled this PR with the 'WIP' label if it is a work in progress.
* [x] Labeled this PR with the labels corresponding to the changed package.
