### PR TITLE
Move all dependencies on @0xproject/types out of devDependencies

### DIFF
--- a/packages/contracts/package.json
+++ b/packages/contracts/package.json
@@ -38,7 +38,6 @@
     "devDependencies": {
         "@0xproject/dev-utils": "^0.1.0",
         "@0xproject/tslint-config": "^0.4.9",
-        "@0xproject/types": "^0.2.3",
         "@types/bluebird": "^3.5.3",
         "@types/lodash": "^4.14.86",
         "@types/node": "^8.0.53",
@@ -66,6 +65,7 @@
         "0x.js": "^0.32.4",
         "@0xproject/deployer": "^0.1.0",
         "@0xproject/json-schemas": "^0.7.12",
+        "@0xproject/types": "^0.2.3",
         "@0xproject/utils": "^0.3.4",
         "@0xproject/web3-wrapper": "^0.1.14",
         "bluebird": "^3.5.0",

--- a/packages/dev-utils/package.json
+++ b/packages/dev-utils/package.json
@@ -24,7 +24,6 @@
     "homepage": "https://github.com/0xProject/0x.js/packages/dev-utils/README.md",
     "devDependencies": {
         "@0xproject/tslint-config": "^0.4.9",
-        "@0xproject/types": "^0.2.3",
         "@0xproject/web3-wrapper": "^0.1.14",
         "@types/lodash": "^4.14.86",
         "@types/mocha": "^2.2.42",
@@ -40,6 +39,7 @@
     },
     "dependencies": {
         "@0xproject/subproviders": "^0.5.0",
+        "@0xproject/types": "^0.2.3",
         "@0xproject/utils": "^0.3.4",
         "ethereumjs-util": "^5.1.2",
         "lodash": "^4.17.4",

--- a/packages/subproviders/package.json
+++ b/packages/subproviders/package.json
@@ -19,6 +19,7 @@
     },
     "dependencies": {
         "@0xproject/assert": "^0.0.20",
+        "@0xproject/types": "^0.2.3",
         "@0xproject/utils": "^0.3.4",
         "bn.js": "^4.11.8",
         "es6-promisify": "^5.0.0",
@@ -33,7 +34,6 @@
     },
     "devDependencies": {
         "@0xproject/tslint-config": "^0.4.9",
-        "@0xproject/types": "^0.2.3",
         "@0xproject/utils": "^0.3.4",
         "@types/lodash": "^4.14.86",
         "@types/mocha": "^2.2.42",

--- a/packages/utils/package.json
+++ b/packages/utils/package.json
@@ -21,7 +21,6 @@
     "homepage": "https://github.com/0xProject/0x.js/packages/utils/README.md",
     "devDependencies": {
         "@0xproject/tslint-config": "^0.4.9",
-        "@0xproject/types": "^0.2.3",
         "@types/lodash": "^4.14.86",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
@@ -30,6 +29,7 @@
         "web3-typescript-typings": "^0.9.11"
     },
     "dependencies": {
+        "@0xproject/types": "^0.2.3",
         "bignumber.js": "~4.1.0",
         "js-sha3": "^0.7.0",
         "lodash": "^4.17.4",

--- a/packages/web3-wrapper/package.json
+++ b/packages/web3-wrapper/package.json
@@ -21,7 +21,6 @@
     "homepage": "https://github.com/0xProject/0x.js/packages/web3-wrapper/README.md",
     "devDependencies": {
         "@0xproject/tslint-config": "^0.4.9",
-        "@0xproject/types": "^0.2.3",
         "@types/lodash": "^4.14.86",
         "npm-run-all": "^4.1.2",
         "shx": "^0.2.2",
@@ -30,6 +29,7 @@
         "web3-typescript-typings": "^0.9.11"
     },
     "dependencies": {
+        "@0xproject/types": "^0.2.3",
         "@0xproject/utils": "^0.3.4",
         "lodash": "^4.17.4",
         "web3": "^0.20.0"


### PR DESCRIPTION
## Description

Move all instances of `@0xproject/types` that appear in `devDependencies` to `dependencies` instead.

## Motivation and Context

Our `@0xproject/types` package includes compiled JavaScript in addition to types so we must include it in the `dependencies` field in the dependent `package.json` files.

## How Has This Been Tested?

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
* [ ] Added new entries to the relevant CHANGELOGs.
* [ ] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [ ] Labeled this PR with the 'WIP' label if it is a work in progress.
* [ ] Labeled this PR with the labels corresponding to the changed package.
