### PR TITLE
Rename _unsubscribeAll to unsubscribeAll

### DIFF
--- a/packages/0x.js/CHANGELOG.md
+++ b/packages/0x.js/CHANGELOG.md
@@ -2,6 +2,7 @@
 
 ## v0.33.0 - _TBD, 2018_
 
+    * Rename all public `_unsubscribeAll` methods to `unsubscribeAll` (#415)
     * Improve validation to force passing contract addresses on private networks (#385)
 
 ## v0.32.2 - _February 9, 2018_

--- a/packages/0x.js/src/contract_wrappers/ether_token_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/ether_token_wrapper.ts
@@ -151,7 +151,7 @@ export class EtherTokenWrapper extends ContractWrapper {
     /**
      * Cancels all existing subscriptions
      */
-    public _unsubscribeAll(): void {
+    public unsubscribeAll(): void {
         super._unsubscribeAll();
     }
     /**
@@ -168,7 +168,7 @@ export class EtherTokenWrapper extends ContractWrapper {
         return contractAddressIfExists;
     }
     private _invalidateContractInstance(): void {
-        this._unsubscribeAll();
+        this.unsubscribeAll();
         this._etherTokenContractsByAddress = {};
     }
     private async _getEtherTokenContractAsync(etherTokenAddress: string): Promise<EtherTokenContract> {

--- a/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/exchange_wrapper.ts
@@ -679,7 +679,7 @@ export class ExchangeWrapper extends ContractWrapper {
     /**
      * Cancels all existing subscriptions
      */
-    public _unsubscribeAll(): void {
+    public unsubscribeAll(): void {
         super._unsubscribeAll();
     }
     /**
@@ -862,7 +862,7 @@ export class ExchangeWrapper extends ContractWrapper {
         return contractAddress;
     }
     private _invalidateContractInstances(): void {
-        this._unsubscribeAll();
+        this.unsubscribeAll();
         delete this._exchangeContractIfExists;
     }
     private async _isValidSignatureUsingContractCallAsync(

--- a/packages/0x.js/src/contract_wrappers/token_wrapper.ts
+++ b/packages/0x.js/src/contract_wrappers/token_wrapper.ts
@@ -333,7 +333,7 @@ export class TokenWrapper extends ContractWrapper {
     /**
      * Cancels all existing subscriptions
      */
-    public _unsubscribeAll(): void {
+    public unsubscribeAll(): void {
         super._unsubscribeAll();
     }
     /**
@@ -365,7 +365,7 @@ export class TokenWrapper extends ContractWrapper {
         return logs;
     }
     private _invalidateContractInstances(): void {
-        this._unsubscribeAll();
+        this.unsubscribeAll();
         this._tokenContractsByAddress = {};
     }
     private async _getTokenContractAsync(tokenAddress: string): Promise<TokenContract> {

--- a/packages/0x.js/test/ether_token_wrapper_test.ts
+++ b/packages/0x.js/test/ether_token_wrapper_test.ts
@@ -158,7 +158,7 @@ describe('EtherTokenWrapper', () => {
             etherTokenAddress = etherToken.address;
         });
         afterEach(() => {
-            zeroEx.etherToken._unsubscribeAll();
+            zeroEx.etherToken.unsubscribeAll();
         });
         // Hack: Mocha does not allow a test to be both async and have a `done` callback
         // Since we need to await the receipt of the event in the `subscribe` callback,

--- a/packages/0x.js/test/exchange_wrapper_test.ts
+++ b/packages/0x.js/test/exchange_wrapper_test.ts
@@ -922,7 +922,7 @@ describe('ExchangeWrapper', () => {
             );
         });
         afterEach(async () => {
-            zeroEx.exchange._unsubscribeAll();
+            zeroEx.exchange.unsubscribeAll();
         });
         // Hack: Mocha does not allow a test to be both async and have a `done` callback
         // Since we need to await the receipt of the event in the `subscribe` callback,

--- a/packages/0x.js/test/subscription_test.ts
+++ b/packages/0x.js/test/subscription_test.ts
@@ -49,7 +49,7 @@ describe('SubscriptionTest', () => {
             tokenAddress = token.address;
         });
         afterEach(() => {
-            zeroEx.token._unsubscribeAll();
+            zeroEx.token.unsubscribeAll();
             _.each(stubs, s => s.restore());
             stubs = [];
         });
@@ -76,7 +76,7 @@ describe('SubscriptionTest', () => {
                 const callback = (err: Error | null, logEvent?: DecodedLogEvent<ApprovalContractEventArgs>) => _.noop;
                 zeroEx.token.subscribe(tokenAddress, TokenEvents.Approval, indexFilterValues, callback);
                 stubs = [Sinon.stub((zeroEx as any)._web3Wrapper, 'getBlockAsync').throws(new Error('JSON RPC error'))];
-                zeroEx.token._unsubscribeAll();
+                zeroEx.token.unsubscribeAll();
                 done();
             })().catch(done);
         });

--- a/packages/0x.js/test/token_wrapper_test.ts
+++ b/packages/0x.js/test/token_wrapper_test.ts
@@ -377,7 +377,7 @@ describe('TokenWrapper', () => {
             tokenAddress = token.address;
         });
         afterEach(() => {
-            zeroEx.token._unsubscribeAll();
+            zeroEx.token.unsubscribeAll();
         });
         // Hack: Mocha does not allow a test to be both async and have a `done` callback
         // Since we need to await the receipt of the event in the `subscribe` callback,

--- a/packages/website/ts/blockchain.ts
+++ b/packages/website/ts/blockchain.ts
@@ -672,7 +672,7 @@ export class Blockchain {
         }
     }
     private _stopWatchingExchangeLogFillEvents(): void {
-        this._zeroEx.exchange._unsubscribeAll();
+        this._zeroEx.exchange.unsubscribeAll();
     }
     private async _getTokenRegistryTokensByAddressAsync(): Promise<TokenByAddress> {
         utils.assert(!_.isUndefined(this._zeroEx), 'ZeroEx must be instantiated.');


### PR DESCRIPTION
<!--- Thank you for taking the time to submit a Pull Request -->

<!--- Provide a general summary of the issue in the Title above -->

## Description

We accidentally named some public methods `_unsubscribeAll` instead of `unsubscribeAll`.
This fixes that.

## Motivation and Context

<!--- Why is this change required? What problem does it solve? -->

<!--- If it fixes an open issue, please link to the issue here. -->

## How Has This Been Tested?

It builds and passes tests

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [ ] New feature (non-breaking change which adds functionality)
* [x] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [ ] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
* [x] Added new entries to the relevant CHANGELOGs.
* [x] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [x] Labeled this PR with the 'WIP' label if it is a work in progress.
* [x] Labeled this PR with the labels corresponding to the changed package.
