### PR TITLE
Fix a bug with displaying solidity functions returning multiple retur…

### DIFF
--- a/packages/website/ts/utils/doxity_utils.ts
+++ b/packages/website/ts/utils/doxity_utils.ts
@@ -45,11 +45,17 @@ export const doxityUtils = {
             const methods: SolidityMethod[] = _.map<DoxityAbiDoc, SolidityMethod>(
                 doxityMethods,
                 (doxityMethod: DoxityAbiDoc) => {
-                    // We assume that none of our functions returns more then a single value
-                    const outputIfExists = !_.isUndefined(doxityMethod.outputs) ? doxityMethod.outputs[0] : undefined;
-                    const returnTypeIfExists = !_.isUndefined(outputIfExists)
-                        ? this._convertType(outputIfExists.type)
-                        : undefined;
+                    const outputs = !_.isUndefined(doxityMethod.outputs) ? doxityMethod.outputs : [];
+                    let returnTypeIfExists: Type;
+                    if (outputs.length === 0) {
+                        // no-op. It's already undefined
+                    } else if (outputs.length === 1) {
+                        const outputsType = outputs[0].type;
+                        returnTypeIfExists = this._convertType(outputsType);
+                    } else {
+                        const outputsType = `[${_.map(outputs, output => output.type).join(', ')}]`;
+                        returnTypeIfExists = this._convertType(outputsType);
+                    }
                     // For ZRXToken, we want to convert it to zrxToken, rather then simply zRXToken
                     const callPath =
                         contractName !== 'ZRXToken'


### PR DESCRIPTION
…n values

## Description

Before:
<img width="661" alt="screen shot 2018-02-27 at 14 21 11" src="https://user-images.githubusercontent.com/6204356/36758633-e1fe64dc-1bc9-11e8-8781-47450a21255f.png">
After:
<img width="671" alt="screen shot 2018-02-27 at 14 21 04" src="https://user-images.githubusercontent.com/6204356/36758634-e295b12a-1bc9-11e8-92cf-a74f3f0a1772.png">


## Motivation and Context

We initially assumed, that no function will ever return `>1` return value.

## How Has This Been Tested?
Built the website and checked.

## Types of changes

<!--- What types of changes does your code introduce? Put an `x` in all the boxes that apply: -->

* [x] Bug fix (non-breaking change which fixes an issue)
* [x] New feature (non-breaking change which adds functionality)
* [ ] Breaking change (fix or feature that would cause existing functionality to change)

## Checklist:

<!--- Go over all the following points, and put an `x` in all the boxes that apply. -->

<!--- If you're unsure about any of these, don't hesitate to ask. We're here to help! -->

* [x] Change requires a change to the documentation.
* [ ] Added tests to cover my changes.
* [x] Added new entries to the relevant CHANGELOGs.
* [x] Updated the new versions of the changed packages in the relevant CHANGELOGs.
* [x] Labeled this PR with the 'WIP' label if it is a work in progress.
* [x] Labeled this PR with the labels corresponding to the changed package.
